### PR TITLE
Adding kernel search code + messenger config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,10 @@ target_link_libraries(SugarSpice
                       PUBLIC
                       ghc_filesystem 
                       fmt::fmt-header-only 
+                      nlohmann_json::nlohmann_json
                       PRIVATE 
                       CSpice::cspice 
-                      nlohmann_json::nlohmann_json)
+                      )
 
 install(TARGETS SugarSpice LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY ${SUGARSPICE_INCLUDE_DIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -97,7 +98,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
 install(FILES ${SUGARSPICE_HEADER_FILES} DESTINATION ${SUGARSPICE_INSTALL_INCLUDE_DIR})
 
 # Install the library
-install(TARGETS SugarSpice
+install(TARGETS SugarSpice nlohmann_json
         EXPORT sugarSpiceTargets
         LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
         INCLUDES DESTINATION ${SUGARSPICE_INSTALL_INCLUDE_DIR})

--- a/SugarSpice/db/lro.json
+++ b/SugarSpice/db/lro.json
@@ -2,8 +2,8 @@
   "moc" : { 
       "ck" : {
           "reconstructed" : ["soc31.*.bc", "lrolc.*.bc"],
-          "sclk" : "lro_clkcor_???????_v00.tsc", 
-          "lsk" : "naif.????.tls",
+          "sclk" : "lro_clkcor_[0-9]{7}_v00.tsc", 
+          "lsk" : "naif.[0-9]{4}.tls",
           "deps" : []
       },
       "spk" : {

--- a/SugarSpice/db/mess.json
+++ b/SugarSpice/db/mess.json
@@ -1,29 +1,49 @@
 {
     "mdis" : {
         "ck" : {
-            "reconstructed" : "msgr_????_v??.bc",
-            "smithed" : "msgr_mdis_sc????_usgs_v?.bc",
-            "sclk" : "messenger_????.tsc",
-            "lsk" : "naif????.tls",
-            "deps" : ["mess:ck", "mdis_att:ck"]
-        }
+            "reconstructed" : "msgr_[0-9]{4}_v[0-9]{2}.bc",
+            "smithed" : "msgr_mdis_sc[0-9]{4}_usgs_v[0-9]{1}.bc",
+            "deps" : {
+                "sclk" : "messenger_[0-9]{4}.tsc",
+                "lsk" : "naif[0-9]{4}.tls",
+                "objs" : ["mess:ck", "mdis_att:ck"]
+            } 
+        },
+        "spk" : {
+            "reconstructed" : "msgr_20040803.*.bsp",
+            "deps" : {
+                "lsk" : "naif[0-9]{4}.tls",
+                "objs" : []
+            }
+        },
+        "tspk" : {
+            "NA" : ["de423s.bsp", "des405.bsp"]
+        },
+        "fk" : "msgr_v[0-9]{3}.tf",
+        "ik" : "msgr_mdis_v[0-9]{3}.ti",
+        "iak" : "mdisAddendum[0-9]{3}.ti",
+        "pck" : "pck00010_msgr_v[0-9]{2}.tpc"
     },
     "mdis_att" : {
         "ck" : {
-            "reconstructed" : "msgr_mdis_sc??????_??????_sub_v?.bc",
-            "smithed" : "msgr_mdis_sc????_usgs_v?.bc",
-            "sclk" : "messenger_????.tsc",
-            "lsk" : "naif????.tls",
-            "deps" : []   
+            "reconstructed" : "msgr_mdis_sc[0-9]{6}_[0-9]{6}_sub_v[0-9]{1}.bc",
+            "smithed" : "msgr_mdis_sc[0-9]{4}_usgs_v[0-9]{1}.bc",
+            "deps" : {
+                "sclk" : "messenger_[0-9]{4}.tsc",
+                "lsk" : "naif[0-9]{4}.tls",
+                "objs" : []
+            } 
         }
     },
     "mess" : {
         "ck" : {
-            "reconstructed" : "msgr_????_v??.bc",
-            "smithed" : "msgr_mdis_sc????_usgs_v?.bc",
-            "sclk" : "messenger_????.tsc",
-            "lsk" : "naif????.tls",
-            "deps" : []   
+            "reconstructed" : "msgr_[0-9]{4}_v[0-9]{2}.bc",
+            "smithed" : "msgr_mdis_sc[0-9]{4}_usgs_v[0-9]{1}.bc",
+            "deps" : {
+                "sclk" : "messenger_[0-9]{4}.tsc",
+                "lsk" : "naif[0-9]{4}.tls",
+                "objs" : []
+            } 
         }
     }
 }

--- a/SugarSpice/include/query.h
+++ b/SugarSpice/include/query.h
@@ -36,3 +36,17 @@
    * 
   **/
  std::vector<std::string> searchSpk(std::string mission, std::string instrument, double et);
+
+
+ /**
+  * @brief Returns all kernels available for a mission
+  *
+  * Returns a structured json object containing all available kernels for a specified mission 
+  * along with their dependencies.
+  *  
+  * TODO: Add a "See Also" on json format after the format matures a bit more. 
+  *
+  * @param
+  * @returns list of paths matching ext
+  **/
+ nlohmann::json searchMissionKernels(fs::path root, std::string mission);

--- a/SugarSpice/include/query.h
+++ b/SugarSpice/include/query.h
@@ -1,5 +1,10 @@
 #pragma once 
 
+#include <vector>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <ghc/fs_std.hpp>
+
 /** 
   * @file 
   *

--- a/SugarSpice/include/spice_types.h
+++ b/SugarSpice/include/spice_types.h
@@ -19,19 +19,20 @@
 class Kernel {
     public: 
 
-    enum Type {
-      CK=0, SPK, TSPK, 
+    enum class Type { NA=0,
+      CK, SPK, TSPK, 
       LSK, MK, SCLK,
       IAK, IK, FK, 
       DSK, PCK, EK
     }; 
     
-    enum Quality  { 
-        NA = 0,        // Non External Orientation data
-        Predicted,     // Based on predicted location of instrument     
-        Nadir,         // Assumes Nadir pointing   
-        Reconstructed, // 
-        Smithed        // Controlled Kernels
+    enum class Quality  {
+        PREDICTED = 1,     // Based on predicted location of instrument     
+        NADIR = 2,         // Assumes Nadir pointing   
+        RECONSTRUCTED = 3, // 
+        SMITHED = 4,       // Controlled Kernels
+        NA = SMITHED       // Either Quaility doesn't apply (e.g. text kernels) -or- 
+                           // we dont care about quality (e.g. CK of any quality)
     };
 
     const static std::vector<std::string> QUALITIES;

--- a/SugarSpice/include/utils.h
+++ b/SugarSpice/include/utils.h
@@ -47,18 +47,6 @@ std::vector<fs::path> glob(fs::path const & root,
  **/
 std::vector<std::pair<std::string, std::string>> getCkIntervals(std::string kpath, std::string sclk, std::string lsk);
 
-
-/**
-  * @brief This is a short description
-  *
-  * This is a long description 
-  *
-  * 
-  * @returns list of paths matching ext
- **/
- nlohmann::json getMissionKernels(fs::path root, std::string mission);
-
-
 /** 
   *
   *

--- a/SugarSpice/include/utils.h
+++ b/SugarSpice/include/utils.h
@@ -47,6 +47,7 @@ std::vector<fs::path> glob(fs::path const & root,
  **/
 std::vector<std::pair<std::string, std::string>> getCkIntervals(std::string kpath, std::string sclk, std::string lsk);
 
+
 /** 
   *
   *
@@ -57,9 +58,30 @@ std::vector<std::pair<std::string, std::string>> getCkIntervals(std::string kpat
 
 
 /** 
-  *
-  *
-  *
-  *
+  * @brief Returns the path to the Mission specific Spice config file. 
+  * 
+  * Given a mission, search a prioritized list of directories for 
+  * the json config file. This function checks in the order: 
+  *  
+  *   1. The local build dir, i.e. $CMAKE_SOURCE_DIR
+  *   2. The install dir, i.e. $CMAKE_PREFIX 
+  * 
+  * @param mission mission name of the config file 
+  * 
+  * @returns path object of the condig file
  **/
- fs::path getDbFile(std::string mission);
+ fs::path getMissionConfigFile(std::string mission);
+
+
+/** 
+  * @brief Returns std::vector<string> interpretation of a json array. 
+  * 
+  * Attempts to convert the json array to a C++ array. Also handles 
+  * strings in cases where one element arrays are stored as scalars. 
+  * Throws exception if the json obj is not an array. 
+  * 
+  * @param arr input json arr
+  * 
+  * @returns string vector containing arr data
+ **/ 
+ std::vector<std::string> jsonArrayToVector(nlohmann::json arr);

--- a/SugarSpice/include/utils.h
+++ b/SugarSpice/include/utils.h
@@ -13,6 +13,8 @@
 #include <fmt/format.h>
 #include <fmt/compile.h>
 
+#include <nlohmann/json.hpp>
+
 #include <ghc/fs_std.hpp>
 
 #include "spice_types.h"
@@ -54,7 +56,7 @@ std::vector<std::pair<std::string, std::string>> getCkIntervals(std::string kpat
   * 
   * @returns list of paths matching ext
  **/
-fs::path getKernelDir(fs::path root, std::string mission, std::string instrument, Kernel::Type type);
+ nlohmann::json getMissionKernels(fs::path root, std::string mission);
 
 
 /** 

--- a/SugarSpice/src/query.cpp
+++ b/SugarSpice/src/query.cpp
@@ -1,0 +1,145 @@
+/**
+  * @file
+  *
+  *
+  *
+  *
+ **/
+
+#include "query.h"
+
+json searchMissionKernels(fs::path root, string mission) {
+
+  /** 
+    * Lambda for globbing files from a regular expression stored 
+    * in json. As they can wither be a single expression or a 
+    * list, we need to massage the json a little. 
+   **/
+  auto getPathsFromRegex = [&root](json r) -> vector<fs::path> {
+      vector<string> regexes = jsonArrayToVector(r); 
+      regex reg(fmt::format("({})", fmt::join(regexes, "|")));
+      vector<fs::path> paths = glob(root, reg, true);
+
+      return paths;
+  };
+
+  /**
+    * Lambda for parsing a CK json object, returns a json object 
+    * with a similar structure, but regexes replaces with a path list
+   **/
+  auto globCks = [&](json category) -> json {
+    if(!category.contains("ck")) {
+      return (json){};
+    }
+
+    category = category["ck"];
+    json ret;
+    
+    for(auto qual: Kernel::QUALITIES) {
+      if(!category.contains(qual)) {
+        continue; 
+      }
+      ret[qual] = getPathsFromRegex(category[qual]);
+    }
+
+    // pass deps through
+    if (category.at("deps").contains("objs")) {
+      ret["deps"]["objs"] = category.at("deps").at("objs");
+    }
+    
+    ret["deps"]["sclk"] = getPathsFromRegex(category.at("deps").at("sclk"));
+    ret["deps"]["lsk"] = getPathsFromRegex(category.at("deps").at("lsk"));
+    return ret;
+  };
+
+  /**
+    * Lambda for parsing a SPK json object, returns a json object 
+    * with a similar structure, but regexes replaces with a path list
+   **/
+  auto globSpks = [&](json category) -> json {
+    if(!category.contains("spk")) {
+      return (json){};
+    }
+    
+    category = category["ck"];
+    json ret; 
+
+    for(auto qual: Kernel::QUALITIES) {
+      if(!category.contains(qual)) {
+        continue; 
+      }
+      ret[qual] = getPathsFromRegex(category[qual]);
+    }
+
+    // pass deps through
+    if (category.at("deps").contains("objs")) {
+      ret["deps"]["objs"] = category.at("deps").at("objs");
+    }
+
+    ret["deps"]["sclk"] = getPathsFromRegex(category.at("deps").value("sclk", "$^"));
+    ret["deps"]["lsk"] = getPathsFromRegex(category.at("deps").value("lsk", "$^"));
+    std::cout << category << std::endl;    
+
+    return ret; 
+  };
+
+  /**
+    * Lambda for parsing a FK json object, returns a json object 
+    * with a similar structure, but regexes replaces with a path list
+   **/
+  auto globFks = [&](json category) -> json {
+    json ret; 
+    return getPathsFromRegex(category.value("fk", "$^"));
+  };
+
+  /**
+    * Lambda for parsing a IK json object, returns a json object 
+    * with a similar structure, but regexes replaces with a path list
+   **/
+  auto globIks = [&](json category) -> json {
+    json ret; 
+    return getPathsFromRegex(category.value("ik", "$^"));
+  };
+
+  /**
+    * Lambda for parsing a IAK json object, returns a json object 
+    * with a similar structure, but regexes replaces with a path list
+   **/
+  auto globIaks = [&](json category) -> json {
+    json ret; 
+    return getPathsFromRegex(category.value("iak", "$^"));
+  };
+
+  /**
+    * Lambda for parsing a PCK json object, returns a json object 
+    * with a similar structure, but regexes replaces with a path list
+   **/
+  auto globPcks = [&](json category) -> json {
+    json ret; 
+    return getPathsFromRegex(category.value("pck", "$^"));
+  };
+
+  fs::path dbPath = getDbFile(mission);
+  
+  ifstream i(dbPath);
+  json db;
+  i >> db;
+  
+  // first get any dependencies 
+  // string deps = jsonArrayToVector(db[instrument][sType]); 
+
+  json kernels; 
+
+  // iterate the categories (e.g. missions)
+  for (auto& cat: db.items()) {
+      kernels[cat.key()]["ck"] = globCks(cat.value());
+      kernels[cat.key()]["spk"] = globSpks(cat.value());
+      kernels[cat.key()]["fk"] = globSpks(cat.value());
+      kernels[cat.key()]["fk"] = globFks(cat.value());
+      kernels[cat.key()]["ik"] = globIks(cat.value());
+      kernels[cat.key()]["iak"] = globIaks(cat.value());
+      kernels[cat.key()]["pck"] = globPcks(cat.value());
+  }
+
+  return kernels;
+}

--- a/SugarSpice/src/query.cpp
+++ b/SugarSpice/src/query.cpp
@@ -7,6 +7,10 @@
  **/
 
 #include "query.h"
+#include "utils.h"
+
+using json = nlohmann::json;
+using namespace std;
 
 json searchMissionKernels(fs::path root, string mission) {
 
@@ -119,7 +123,7 @@ json searchMissionKernels(fs::path root, string mission) {
     return getPathsFromRegex(category.value("pck", "$^"));
   };
 
-  fs::path dbPath = getDbFile(mission);
+  fs::path dbPath = getMissionConfigFile(mission);
   
   ifstream i(dbPath);
   json db;

--- a/SugarSpice/src/spice_types.cpp
+++ b/SugarSpice/src/spice_types.cpp
@@ -30,19 +30,20 @@ template < typename T> pair<bool, int > findInVector(const std::vector<T>  & vec
 }
 
 
-const std::vector<std::string> Kernel::TYPES =  {"ck", "spk", "tspk", 
+const std::vector<std::string> Kernel::TYPES =  {"na", "ck", "spk", "tspk", 
                                            "lsk", "mk", "sclk", 
                                            "iak", "ik", "fk", 
                                            "dsk", "pck", "ek"};
 
-const std::vector<std::string> Kernel::QUALITIES = {"predicted",
+const std::vector<std::string> Kernel::QUALITIES = { "NA",
+                                                     "predicted",
                                                      "nadir", 
                                                      "reconstructed", 
                                                      "smithed"};
 
 
 string Kernel::translateType(Kernel::Type type) { 
-    return Kernel::TYPES[type];
+    return Kernel::TYPES[static_cast<int>(type)];
 }
 
 
@@ -57,7 +58,7 @@ Kernel::Type Kernel::translateType(string type) {
 
 
 string Kernel::translateQuality(Kernel::Quality qa) {
-    return Kernel::QUALITIES[qa];
+    return Kernel::QUALITIES[static_cast<int>(qa)];
 }
 
 Kernel::Quality Kernel::translateQuality(string qa) {

--- a/SugarSpice/src/utils.cpp
+++ b/SugarSpice/src/utils.cpp
@@ -247,7 +247,7 @@ vector<pair<string, string>> getCkIntervals(string kpath, string sclk, string ls
 }
 
 
-fs::path getDbFile(string mission) { 
+fs::path getDbFile(string mission) {
     // If running tests or debugging locally 
     fs::path debugDbPath = fs::absolute(_SOURCE_PREFIX) / "SugarSpice" / "db";
     fs::path installDbPath = fs::absolute(_INSTALL_PREFIX) / "etc" / "SugarSpice" / "db";
@@ -269,132 +269,6 @@ fs::path getDbFile(string mission) {
     }
 
     throw invalid_argument(fmt::format("DB file for \"{}\" not found", mission));
-}
-
-
-json getMissionKernels(fs::path root, string mission) {
-  auto parseDeps = [&](json db, vector<string> deps) -> json {
-    return "";
-  };
-
-  auto getKernelsCkFromJson = [](json j, Kernel::Type t, Kernel::Quality q) -> vector<fs::path> {
-    string sType = Kernel::translateType(t);
-    string sQa = Kernel::translateQuality(q);
-
-    // Start at the highest requested Quality, then try lower quality kernels if not available
-    auto highestQa = Kernel::QUALITIES.begin() + static_cast<int>(q);
-    for (auto it = highestQa; it == Kernel::QUALITIES.begin(); it--) {
-      if (!j.contains(*it)) { 
-
-      }
-    }
-    return {};
-  };
-  
-  auto getPathsFromRegex = [&root](json r) -> vector<fs::path> {
-      vector<string> regexes = jsonArrayToVector(r); 
-      regex reg(fmt::format("({})", fmt::join(regexes, "|")));
-      vector<fs::path> paths = glob(root, reg, true);
-
-      return paths;
-  };
-
-  auto globCks = [&](json category) -> json {
-    if(!category.contains("ck")) {
-      return (json){};
-    }
-
-    category = category["ck"];
-    json ret;
-    
-    for(auto qual: Kernel::QUALITIES) {
-      if(!category.contains(qual)) {
-        continue; 
-      }
-      ret[qual] = getPathsFromRegex(category[qual]);
-    }
-
-    // pass deps through
-    if (category.at("deps").contains("objs")) {
-      ret["deps"]["objs"] = category.at("deps").at("objs");
-    }
-    
-    ret["deps"]["sclk"] = getPathsFromRegex(category.at("deps").at("sclk"));
-    ret["deps"]["lsk"] = getPathsFromRegex(category.at("deps").at("lsk"));
-    return ret;
-  };
-
-  auto globSpks = [&](json category) -> json {
-    if(!category.contains("spk")) {
-      return (json){};
-    }
-    
-    category = category["ck"];
-    json ret; 
-
-    for(auto qual: Kernel::QUALITIES) {
-      if(!category.contains(qual)) {
-        continue; 
-      }
-      ret[qual] = getPathsFromRegex(category[qual]);
-    }
-
-    // pass deps through
-    if (category.at("deps").contains("objs")) {
-      ret["deps"]["objs"] = category.at("deps").at("objs");
-    }
-
-    ret["deps"]["sclk"] = getPathsFromRegex(category.at("deps").value("sclk", "$^"));
-    ret["deps"]["lsk"] = getPathsFromRegex(category.at("deps").value("lsk", "$^"));
-    std::cout << category << std::endl;    
-
-    return ret; 
-  };
-
-  auto globFks = [&](json category) -> json {
-    json ret; 
-    std::cout << category << std::endl; 
-    return getPathsFromRegex(category.value("fk", "$^"));
-  };
-
-  auto globIks = [&](json category) -> json {
-    json ret; 
-    return getPathsFromRegex(category.value("ik", "$^"));
-  };
-
-  auto globIaks = [&](json category) -> json {
-    json ret; 
-    return getPathsFromRegex(category.value("iak", "$^"));
-  };
-
-  auto globPcks = [&](json category) -> json {
-    json ret; 
-    return getPathsFromRegex(category.value("pck", "$^"));
-  };
-
-  fs::path dbPath = getDbFile(mission);
-  
-  ifstream i(dbPath);
-  json db;
-  i >> db;
-  
-  // first get any dependencies 
-  // string deps = jsonArrayToVector(db[instrument][sType]); 
-
-  json kernels; 
-
-  // iterate the categories (e.g. missions)
-  for (auto& cat: db.items()) {
-      kernels[cat.key()]["ck"] = globCks(cat.value());
-      kernels[cat.key()]["spk"] = globSpks(cat.value());
-      kernels[cat.key()]["fk"] = globSpks(cat.value());
-      kernels[cat.key()]["fk"] = globFks(cat.value());
-      kernels[cat.key()]["ik"] = globIks(cat.value());
-      kernels[cat.key()]["iak"] = globIaks(cat.value());
-      kernels[cat.key()]["pck"] = globPcks(cat.value());
-  }
-
-  return kernels;
 }
 
 

--- a/SugarSpice/src/utils.cpp
+++ b/SugarSpice/src/utils.cpp
@@ -247,7 +247,7 @@ vector<pair<string, string>> getCkIntervals(string kpath, string sclk, string ls
 }
 
 
-fs::path getDbFile(string mission) {
+fs::path getMissionConfigFile(string mission) {
     // If running tests or debugging locally 
     fs::path debugDbPath = fs::absolute(_SOURCE_PREFIX) / "SugarSpice" / "db";
     fs::path installDbPath = fs::absolute(_INSTALL_PREFIX) / "etc" / "SugarSpice" / "db";

--- a/SugarSpice/tests/UtilTests.cpp
+++ b/SugarSpice/tests/UtilTests.cpp
@@ -4,25 +4,17 @@
 #include "Fixtures.h"
 #include "spice_types.h"
 
+
 TEST(UtilTests, GetKernelType) { 
-   std::cout << getKernelType("/usgs/cpkgs/isis3/isis_data/lro/kernels/fk/lro_frames_2007322_v01.tf") << std::endl;
-   EXPECT_TRUE(0); 
 }
 
 
 TEST(UtilTests, GetFrameCode) { 
-   std::cout << Kernel::translateFrame("MERCURY") << std::endl;
-   EXPECT_TRUE(0); 
 }
 
 
-TEST(UtilTests, GetFrameName) { 
-   Kernel::translateFrame(199);
-   EXPECT_TRUE(0); 
+TEST(UtilTests, GetFrameName) {  
 }
 
 TEST(UtilTests, GetKernelDirs) { 
-    getDbFile("lro"); 
-    getKernelDir("/data/spice/", "", "", Kernel::Type::CK);
-
 }


### PR DESCRIPTION
this adds the initial code for getting all available kernels and kernel dependencies for a single mission. Messenger was chosen because of the complicated CK path required to run properly as MDIS is mounted on a gimbal. 

Example output: https://gist.github.com/Kelvinrr/3e383d62eead58c016b7165acdf64d60

Next steps is further refining the search and adding more instrument support. Thankfully they are two are orthogonal problems. 
