### PR TITLE
Fixed problem with docs not finding headers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,17 +29,13 @@ def configureDoxyfile(input_dir, output_dir):
     with open('Doxyfile', 'w') as file:
         file.write(filedata)
 
-# Check if we're running on Read the Docs' servers
-read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
-
 breathe_projects = {}
 
-if read_the_docs_build:
-    input_dir = '../SugarSpice'
-    output_dir = '../build/docs/doxygen'
-    configureDoxyfile(input_dir, output_dir)
-    subprocess.call('doxygen', shell=True)
-    breathe_projects['SugarSpice'] = output_dir + '/xml'
+input_dir = '../SugarSpice'
+output_dir = '../build/docs/doxygen'
+configureDoxyfile(input_dir, output_dir)
+subprocess.call('doxygen', shell=True)
+breathe_projects['SugarSpice'] = output_dir + '/xml'
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Removes a check for an environment variable that is never set.  Failure to set the environment variable caused the doxyfile to be parameterized with default values.

Fixes #2 