### PR TITLE
Added clem1 conf and tests

### DIFF
--- a/SugarSpice/db/clem1.json
+++ b/SugarSpice/db/clem1.json
@@ -20,9 +20,23 @@
   },
   "UVVIS" : {
     "ik" : "clem_uvvis_beta_ik_v04.ti",
-    "iak" : "uvvisAddendum[0-9]{3}.ti"
+    "iak" : "uvvisAddendum[0-9]{3}.ti",
+    "ck" : {
+      "deps" : {
+        "sclk" : "dspse[0-9]{3}.tsc",
+        "lsk" : "naif[0-9]{4}.tls",
+        "objs" : ["clem:ck"]
+      }
+    }
   },
   "NIR" : {
     "iak" : "nirAddendum[0-9]{3}.ti"
+    "ck" : {
+      "deps" : {
+        "sclk" : "dspse[0-9]{3}.tsc",
+        "lsk" : "naif[0-9]{4}.tls",
+        "objs" : ["clem:ck"]
+      }
+    }
   }
 }

--- a/SugarSpice/db/clem1.json
+++ b/SugarSpice/db/clem1.json
@@ -1,0 +1,28 @@
+{
+  "clem" : {
+    "ck" : {
+      "reconstructed" : "clem_[0-9]{3}.bck",
+      "smithed" : "clem_ulcn2005_6hr.bc",
+      "deps" : {
+        "sclk" : "dspse[0-9]{3}.tsc",
+        "lsk" : "naif[0-9]{4}.tls",
+        "objs" : []
+      }
+    },
+    "spk" : {
+      "reconstructed" : "clem.*\\.bsp",
+      "deps" : {
+        "lsk" : "naif[0-9]{4}.tls",
+        "objs" : []
+      }
+    },
+    "fk" : "clem_v[0-9]{2}.tf"
+  },
+  "UVVIS" : {
+    "ik" : "clem_uvvis_beta_ik_v04.ti",
+    "iak" : "uvvisAddendum[0-9]{3}.ti"
+  },
+  "NIR" : {
+    "iak" : "nirAddendum[0-9]{3}.ti"
+  }
+}

--- a/SugarSpice/db/clem1.json
+++ b/SugarSpice/db/clem1.json
@@ -30,7 +30,7 @@
     }
   },
   "NIR" : {
-    "iak" : "nirAddendum[0-9]{3}.ti"
+    "iak" : "nirAddendum[0-9]{3}.ti",
     "ck" : {
       "deps" : {
         "sclk" : "dspse[0-9]{3}.tsc",

--- a/SugarSpice/db/clem1.json
+++ b/SugarSpice/db/clem1.json
@@ -27,6 +27,11 @@
         "lsk" : "naif[0-9]{4}.tls",
         "objs" : ["clem:ck"]
       }
+    },
+    "spk" : {
+      "deps" : {
+        "objs" : ["clem:spk"]
+      }
     }
   },
   "NIR" : {
@@ -36,6 +41,11 @@
         "sclk" : "dspse[0-9]{3}.tsc",
         "lsk" : "naif[0-9]{4}.tls",
         "objs" : ["clem:ck"]
+      }
+    },
+    "spk" : {
+      "deps" : {
+        "objs" : ["clem:spk"]
       }
     }
   }

--- a/SugarSpice/tests/Fixtures.cpp
+++ b/SugarSpice/tests/Fixtures.cpp
@@ -49,7 +49,8 @@ void TempTestingFiles::TearDown() {
 
 void KernelDataDirectories::SetUp() {
   // combine multiple path lists here as we add more.
-  paths = mess_paths;
+  paths = base_paths;
+  paths.insert(paths.end(), mess_paths.begin(), mess_paths.end());
   paths.insert(paths.end(), clem1_paths.begin(), clem1_paths.end());
 }
 

--- a/SugarSpice/tests/Fixtures.cpp
+++ b/SugarSpice/tests/Fixtures.cpp
@@ -10,10 +10,10 @@
 
 #include "utils.h"
 
-using namespace std; 
+using namespace std;
 
 
-void TempTestingFiles::SetUp() { 
+void TempTestingFiles::SetUp() {
   int max_tries = 10;
   auto tmp_dir = fs::temp_directory_path();
   unsigned long long i = 0;
@@ -26,7 +26,7 @@ void TempTestingFiles::SetUp() {
     stringstream ss;
     ss << "SSTESTS" << hex << rand(prng);
     tpath = tmp_dir / ss.str();
-    
+
     // true if the directory was created.
     if (fs::create_directory(tpath)) {
         break;
@@ -47,9 +47,10 @@ void TempTestingFiles::TearDown() {
 }
 
 
-void KernelDataDirectories::SetUp() { 
-  // combine multiple path lists here as we add more. 
+void KernelDataDirectories::SetUp() {
+  // combine multiple path lists here as we add more.
   paths = mess_paths;
+  paths.insert(paths.end(), clem1_paths.begin(), clem1_paths.end());
 }
 
 void KernelDataDirectories::TearDown() {

--- a/SugarSpice/tests/Paths.h
+++ b/SugarSpice/tests/Paths.h
@@ -2,14 +2,18 @@
 #include <ghc/fs_std.hpp>
 
 
+// paths for testing base / shared kernel queries
+std::vector<fs::path> base_paths = {
+    "/isis_data/base/kernels/sclk/naif0001.tls",
+    "/isis_data/base/kernels/sclk/naif0002.tls",
+}
+
 // paths for testing messenger kernel queries
 std::vector<fs::path> mess_paths = {
     "/isis_data/messenger/kernels/ck/msgr_1234_v01.bc",
     "/isis_data/messenger/kernels/ck/msgr_1235_v01.bc",
     "/isis_data/messenger/kernels/ck/msgr_1235_v02.bc",
     "/isis_data/messenger/kernels/ck/msgr_1236_v03.bc",
-    "/isis_data/base/kernels/sclk/naif0001.tls",
-    "/isis_data/base/kernels/sclk/naif0002.tls",
     "/isis_data/messenger/kernels/sclk/messenger_0001.tsc",
     "/isis_data/messenger/kernels/sclk/messenger_0002.tsc",
     "/isis_data/messenger/kernels/spk/msgr_20040803_20150328_od360sc_0.bsp",

--- a/SugarSpice/tests/Paths.h
+++ b/SugarSpice/tests/Paths.h
@@ -2,7 +2,7 @@
 #include <ghc/fs_std.hpp>
 
 
-// paths for testing messenger kernel queries 
+// paths for testing messenger kernel queries
 std::vector<fs::path> mess_paths = {
     "/isis_data/messenger/kernels/ck/msgr_1234_v01.bc",
     "/isis_data/messenger/kernels/ck/msgr_1235_v01.bc",
@@ -41,4 +41,29 @@ std::vector<fs::path> mess_paths = {
     "/isis_data/messenger/kernels/ck/msgr_mdis_gm012345_112233v1.bc",
     "/isis_data/messenger/kernels/ck/msgr_mdis_gm332211_999999v1.bc",
     "/isis_data/messenger/kernels/ck/msgr_mdis_gm012345_999999v2.bc"
+};
+
+// paths for testing clementine kernel queries
+std::vector<fs::path> clem1_paths = {
+    "/isis_data/clementine1/kernels/ck/clem_123.bck",
+    "/isis_data/clementine1/kernels/ck/clem_124.bck",
+    "/isis_data/clementine1/kernels/ck/clem_125.bck",
+    "/isis_data/clementine1/kernels/ck/clem_126.bck",
+
+    "/isis_data/clementine1/kernels/ck/clem_ulcn2005_6hr.bc",
+
+    "/isis_data/clementine1/kernels/sclk/dspse001.tsc",
+    "/isis_data/clementine1/kernels/sclk/dspse002.tsc",
+
+    "/isis_data/clementine1/kernels/spk/clem_123_v01.bsp",
+    "/isis_data/clementine1/kernels/spk/clem_124_v01.bsp",
+
+    "/isis_data/clementine1/kernels/fk/clem_v01.tf",
+
+    "/isis_data/clementine1/kernels/ik/clem_uvvis_beta_ik_v04.ti",
+
+    "/isis_data/clementine1/kernels/iak/uvvisAddendum001.ti",
+    "/isis_data/clementine1/kernels/iak/uvvisAddendum002.ti",
+    "/isis_data/clementine1/kernels/iak/nirAddendum001.ti",
+    "/isis_data/clementine1/kernels/iak/nirAddendum002.ti"
 };

--- a/SugarSpice/tests/Paths.h
+++ b/SugarSpice/tests/Paths.h
@@ -5,8 +5,8 @@
 // paths for testing base / shared kernel queries
 std::vector<fs::path> base_paths = {
     "/isis_data/base/kernels/sclk/naif0001.tls",
-    "/isis_data/base/kernels/sclk/naif0002.tls",
-}
+    "/isis_data/base/kernels/sclk/naif0002.tls"
+};
 
 // paths for testing messenger kernel queries
 std::vector<fs::path> mess_paths = {

--- a/SugarSpice/tests/QueryTests.cpp
+++ b/SugarSpice/tests/QueryTests.cpp
@@ -11,14 +11,14 @@ using namespace std;
 
 TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernels) {
   fs::path dbPath = getMissionConfigFile("mess");
-  
+
   ifstream i(dbPath);
   nlohmann::json conf;
   i >> conf;
 
   MockRepository mocks;
   mocks.OnCallFunc(ls).Return(paths);
-  
+
   nlohmann::json res = searchMissionKernels("/isis_data/", conf);
 
   ASSERT_EQ(res["mdis"]["ck"]["reconstructed"].size(), 4);
@@ -28,7 +28,7 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernels) {
   ASSERT_EQ(res["mdis"]["ck"]["deps"]["objs"].size(), 2);
   ASSERT_EQ(res["mdis"]["spk"]["reconstructed"].size(), 2);
   ASSERT_EQ(res["mdis"]["spk"]["deps"]["lsk"].size(), 2);
-  ASSERT_EQ(res["mdis"]["tspk"]["na"].size(), 1); 
+  ASSERT_EQ(res["mdis"]["tspk"]["na"].size(), 1);
   ASSERT_EQ(res["mdis"]["fk"].size(), 2);
   ASSERT_EQ(res["mdis"]["ik"].size(), 2);
   ASSERT_EQ(res["mdis"]["iak"].size(), 2);
@@ -43,5 +43,33 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernels) {
   ASSERT_EQ(res["mess"]["ck"]["deps"]["sclk"].size(), 2);
   ASSERT_EQ(res["mess"]["ck"]["deps"]["lsk"].size(), 2);
   ASSERT_EQ(res["mess"]["ck"]["deps"]["objs"].size(), 0);
- 
+
+}
+
+TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsClem1) {
+  fs::path dbPath = getMissionConfigFile("clem1");
+
+  ifstream i(dbPath);
+  nlohmann::json conf;
+  i >> conf;
+
+  MockRepository mocks;
+  mocks.OnCallFunc(ls).Return(paths);
+
+  nlohmann::json res = searchMissionKernels("/isis_data/", conf);
+  std::cout << res << '\n';
+
+  ASSERT_EQ(res["clem"]["ck"]["reconstructed"].size(), 4);
+  ASSERT_EQ(res["clem"]["ck"]["smithed"].size(), 1);
+  ASSERT_EQ(res["clem"]["ck"]["deps"]["sclk"].size(), 2);
+  ASSERT_EQ(res["clem"]["ck"]["deps"]["lsk"].size(), 2);
+  ASSERT_EQ(res["clem"]["ck"]["deps"]["objs"].size(), 0);
+  ASSERT_EQ(res["clem"]["spk"]["reconstructed"].size(), 2);
+  ASSERT_EQ(res["clem"]["spk"]["deps"]["lsk"].size(), 2);
+  ASSERT_EQ(res["clem"]["fk"].size(), 1);
+
+  ASSERT_EQ(res["UVVIS"]["ik"].size(), 1);
+  ASSERT_EQ(res["UVVIS"]["iak"].size(), 2);
+
+  ASSERT_EQ(res["UVVIS"]["iak"].size(), 2);
 }

--- a/SugarSpice/tests/QueryTests.cpp
+++ b/SugarSpice/tests/QueryTests.cpp
@@ -57,7 +57,6 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsClem1) {
   mocks.OnCallFunc(ls).Return(paths);
 
   nlohmann::json res = searchMissionKernels("/isis_data/", conf);
-  std::cout << res << '\n';
 
   ASSERT_EQ(res["clem"]["ck"]["reconstructed"].size(), 4);
   ASSERT_EQ(res["clem"]["ck"]["smithed"].size(), 1);


### PR DESCRIPTION
Some interesting little bits on testing:

The regex for clementine reconstructed spks was just *.*\.bsp, but that picked up all the .bsp files in the 'paths' variable whether or not they were related to clem, so I prefixed it with 'clem'.  This _should_  be ok, because the clementine isis path includes 'clementine1'

Any kernels shared among missions should not be added in subsequent missions "path" listing in paths.h.  For instance, mess.json and clem1.json both include dependencies on naif[0-9]{4}.tls.  I initially added this to the clem1 path, but it picks files in both clem1 and mess paths, so I got double the number of lsks that I thought I'd get.  It might make sense to put these in a "base_paths" variable in Paths.h.