### PR TITLE
Added the ability to only build the docs

### DIFF
--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -115,7 +115,7 @@ jobs:
         cmake --build . --config $BUILD_TYPE
 
     - name: Check Build Docs
-      working-directory: ${{github.workspace}}/build/docs/sphinx/
+      working-directory: ${{github.workspace}}/build/docs/sphinx
       # Check for the built docs
       run: |
           test -e index.html
@@ -129,7 +129,7 @@ jobs:
         cmake --install . --config $BUILD_TYPE
 
     - name: Check Install Docs
-      working-directory: ${{github.workspace}}/build/docs/sphinx/
+      working-directory: ${{github.workspace}}/install
       # Check for the built docs
       run: |
           test -e share/doc/SugarSpice/sphinx/index.html

--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -7,7 +7,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build-unix:
+  build-library:
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -27,32 +27,54 @@ jobs:
           environment-file: environment.yml
           auto-activate-base: false
           auto-update-conda: true
+
     - name: Conda info
       run: |
           conda info
           conda list
+
     - name: Checkout submodules
       uses: snickerbockers/submodules-init@v4
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      run: cmake -E make_directory ${{github.workspace}}/build
+      # Some projects don't allow in-source building, so create separate build and install
+      # directorie; we'll use them as our working directories for subsequent commands.
+      run: |
+          cmake -E make_directory ${{github.workspace}}/build
+          cmake -E make_directory ${{github.workspace}}/install
 
     - name: Configure CMake
       working-directory: ${{github.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCSpice_DIR=$CONDA/envs/sugar_spice/lib/cmake/cspice/ -Dfmt_DIR=$CONDA/envs/sugar_spice/lib/cmake/fmt/ -DSUGARSPICE_BUILD_DOCS=OFF
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCSpice_DIR=$CONDA/envs/sugar_spice/lib/cmake/cspice/ -Dfmt_DIR=$CONDA/envs/sugar_spice/lib/cmake/fmt/ -DSUGARSPICE_BUILD_DOCS=OFF -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
 
     - name: Build
       working-directory: ${{github.workspace}}/build
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: |
         cmake --build . --config $BUILD_TYPE
+
     - name: Test
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -VV -C $BUILD_TYPE
+
+    - name: Install
+      working-directory: ${{github.workspace}}/build
+      # Execute the install.  You can specify a specific target with "--target <NAME>"
+      run: |
+        cmake --install . --config $BUILD_TYPE
+
+    - name: Check install
+      working-directory: ${{github.workspace}}/install
+      # Check that the library installed properly
+      run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            test -e lib/libSugarSpice.dylib
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            test -e lib/libSugarSpice.so
+          fi
+          test -e include/SugarSpice/sugar_spice.h
 
   build-docs:
 
@@ -69,28 +91,47 @@ jobs:
           environment-file: environment.yml
           auto-activate-base: false
           auto-update-conda: true
+
     - name: Conda info
       run: |
           conda info
           conda list
+
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      run: cmake -E make_directory ${{github.workspace}}/build
+      # Some projects don't allow in-source building, so create separate build and install
+      # directorie; we'll use them as our working directories for subsequent commands.
+      run: |
+          cmake -E make_directory ${{github.workspace}}/build
+          cmake -E make_directory ${{github.workspace}}/install
 
     - name: Configure CMake
       working-directory: ${{github.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSUGARSPICE_BUILD_LIB=OFF
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSUGARSPICE_BUILD_LIB=OFF -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
 
     - name: Build
       working-directory: ${{github.workspace}}/build
       # Execute the build.
       run: |
         cmake --build . --config $BUILD_TYPE
-    - name: Check Docs
+
+    - name: Check Build Docs
       working-directory: ${{github.workspace}}/build/docs/sphinx/
       # Check for the built docs
       run: |
           test -e index.html
           test -e reference/api.html
           test -e reference/tutorials.html
+
+    - name: Install Docs
+      working-directory: ${{github.workspace}}/build
+      # Install the build.
+      run: |
+        cmake --install . --config $BUILD_TYPE
+
+    - name: Check Install Docs
+      working-directory: ${{github.workspace}}/build/docs/sphinx/
+      # Check for the built docs
+      run: |
+          test -e share/doc/SugarSpice/sphinx/index.html
+          test -e share/doc/SugarSpice/sphinx/reference/api.html
+          test -e share/doc/SugarSpice/sphinx/reference/tutorials.html

--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -69,9 +69,9 @@ jobs:
       working-directory: ${{github.workspace}}/install
       # Check that the library installed properly
       run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
+          if [ "$RUNNER_OS" == "macOS" ]; then
             test -e lib/libSugarSpice.dylib
-          elif [ "$RUNNER_OS" == "macOS" ]; then
+          elif [ "$RUNNER_OS" == "Linux" ]; then
             test -e lib/libSugarSpice.so
           fi
           test -e include/SugarSpice/sugar_spice.h

--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Configure CMake
       working-directory: ${{github.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE# -DCSpice_DIR=$CONDA/envs/sugar_spice/lib/cmake/cspice/ -Dfmt_DIR=$CONDA/envs/sugar_spice/lib/cmake/fmt/
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCSpice_DIR=$CONDA/envs/sugar_spice/lib/cmake/cspice/ -Dfmt_DIR=$CONDA/envs/sugar_spice/lib/cmake/fmt/ -DSUGARSPICE_BUILD_DOCS=OFF
 
     - name: Build
       working-directory: ${{github.workspace}}/build
@@ -50,6 +50,47 @@ jobs:
         cmake --build . --config $BUILD_TYPE
     - name: Test
       working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
+      # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -VV -C $BUILD_TYPE
+
+  build-docs:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+          miniconda-version: "latest"
+          activate-environment: sugar_spice
+          environment-file: environment.yml
+          auto-activate-base: false
+          auto-update-conda: true
+    - name: Conda info
+      run: |
+          conda info
+          conda list
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      working-directory: ${{github.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSUGARSPICE_BUILD_LIB=OFF
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      # Execute the build.
+      run: |
+        cmake --build . --config $BUILD_TYPE
+    - name: Check Docs
+      working-directory: ${{github.workspace}}/build/docs/sphinx/
+      # Check for the built docs
+      run: |
+          test -e index.html
+          test -e reference/api.html
+          test -e reference/tutorials.html

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 *.app
 
 build/
+install/
 Doxyfile
 
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,10 @@
+include(CMakeDependentOption)
 cmake_minimum_required(VERSION 3.10)
 project(SugarSpice VERSION 0.0.1 DESCRIPTION "Syntax Sugar for cspice")
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 set(CMAKE_CXX_STANDARD 20)
-
-include(CMakeDependentOption)
-
-# Build options
-option (SUGARSPICE_BUILD_LIB "Build the SugarSpice Library" ON)
-option (SUGARSPICE_BUILD_DOCS "Build the SugarSpice Docs" ON)
-cmake_dependent_option (SUGARSPICE_BUILD_TESTS "Build the SugarSpice Tests" ON SUGARSPICE_BUILD_LIB OFF)
 
 # Variables required by multiple build options
 set(SUGARSPICE_BUILD_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/include/")
@@ -30,6 +24,8 @@ message(STATUS "Using install prefix: ${CMAKE_INSTALL_PREFIX}")
 #################
 # Library Build #
 #################
+
+option (SUGARSPICE_BUILD_LIB "Build the SugarSpice Library" ON)
 
 if(SUGARSPICE_BUILD_LIB)
 
@@ -119,6 +115,8 @@ endif()
 # Tests Build #
 ###############
 
+cmake_dependent_option (SUGARSPICE_BUILD_TESTS "Build the SugarSpice Tests" ON SUGARSPICE_BUILD_LIB OFF)
+
 if(SUGARSPICE_BUILD_TESTS)
   include(GoogleTest)
   include(cmake/gtest.cmake)
@@ -134,6 +132,8 @@ endif()
 ##############
 # Docs Build #
 ##############
+
+option (SUGARSPICE_BUILD_DOCS "Build the SugarSpice Docs" ON)
 
 if(SUGARSPICE_BUILD_DOCS)
   add_subdirectory ("docs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,24 +16,23 @@ cmake_dependent_option (SUGARSPICE_BUILD_TESTS "Build the SugarSpice Tests" ON S
 # Variables required by multiple build options
 set(SUGARSPICE_BUILD_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/include/")
 
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+endif()
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
+endif()
+message(STATUS "Using install prefix: ${CMAKE_INSTALL_PREFIX}")
+
 #################
 # Library Build #
 #################
 
 if(SUGARSPICE_BUILD_LIB)
-
-  # Set a default build type if none was specified
-  set(default_build_type "Release")
-  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-        STRING "Choose the type of build." FORCE)
-  endif()
-
-  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
-  endif()
-  message(STATUS "Using install prefix: ${CMAKE_INSTALL_PREFIX}")
 
   set(JSON_BuildTests OFF CACHE INTERNAL "")
 
@@ -43,7 +42,6 @@ if(SUGARSPICE_BUILD_LIB)
   find_package(CSpice REQUIRED)
   find_package(fmt REQUIRED)
 
-  # Library setup
   set(SUGARSPICE_INSTALL_INCLUDE_DIR "include/SugarSpice")
   set(SUGARSPICE_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/utils.cpp
                           ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/io.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_CXX_STANDARD 20)
 # set(CMAKE_CXX_COMPILER "$ENV{PREFIX}/bin/clang")
 
+# Build options
+option (SUGARSPICE_BUILD_DOCS "Build Docs" ON)
+option (SUGARSPICE_BUILD_TESTS "Build tests" ON)
+
 # Set a default build type if none was specified
 set(default_build_type "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -32,7 +36,7 @@ set(SUGARSPICE_BUILD_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/include
 set(SUGARSPICE_INSTALL_INCLUDE_DIR "include/SugarSpice")
 set(SUGARSPICE_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/utils.cpp
                          ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/io.cpp
-                         ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/query.cpp 
+                         ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/query.cpp
                          ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/spice_types.cpp)
 
 set(SUGARSPICE_HEADER_FILES ${SUGARSPICE_BUILD_INCLUDE_DIR}/sugar_spice.h
@@ -61,25 +65,24 @@ target_include_directories(SugarSpice
                            $<INSTALL_INTERFACE:include>
                            PRIVATE)
 
-target_link_libraries(SugarSpice 
+target_link_libraries(SugarSpice
                       PUBLIC
-                      ghc_filesystem 
-                      fmt::fmt-header-only 
+                      ghc_filesystem
+                      fmt::fmt-header-only
                       nlohmann_json::nlohmann_json
-                      PRIVATE 
-                      CSpice::cspice 
+                      PRIVATE
+                      CSpice::cspice
                       )
 
 install(TARGETS SugarSpice LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY ${SUGARSPICE_INCLUDE_DIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Optional build tests
-option (SUGARSPICE_BUILD_TESTS "Build tests" ON)
 if(SUGARSPICE_BUILD_TESTS)
   include(GoogleTest)
   include(cmake/gtest.cmake)
   include(CTest)
-  
+
   find_package (Threads)
   enable_testing()
   add_subdirectory(SugarSpice/tests)
@@ -88,7 +91,6 @@ else()
 endif()
 
 # Setup Docs
-option (SUGARSPICE_BUILD_DOCS "Build Docs" ON)
 if(SUGARSPICE_BUILD_DOCS)
   add_subdirectory ("docs")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(SugarSpice VERSION 0.0.1 DESCRIPTION "Syntax Sugar for cspice")
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 set(CMAKE_CXX_STANDARD 20)
-# set(CMAKE_CXX_COMPILER "$ENV{PREFIX}/bin/clang")
 
 include(CMakeDependentOption)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,78 +6,122 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_CXX_STANDARD 20)
 # set(CMAKE_CXX_COMPILER "$ENV{PREFIX}/bin/clang")
 
+include(CMakeDependentOption)
+
 # Build options
-option (SUGARSPICE_BUILD_DOCS "Build Docs" ON)
-option (SUGARSPICE_BUILD_TESTS "Build tests" ON)
+option (SUGARSPICE_BUILD_LIB "Build the SugarSpice Library" ON)
+option (SUGARSPICE_BUILD_DOCS "Build the SugarSpice Docs" ON)
+cmake_dependent_option (SUGARSPICE_BUILD_TESTS "Build the SugarSpice Tests" ON SUGARSPICE_BUILD_LIB OFF)
 
-# Set a default build type if none was specified
-set(default_build_type "Release")
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-      STRING "Choose the type of build." FORCE)
-endif()
-
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
-endif()
-message(STATUS "Using install prefix: ${CMAKE_INSTALL_PREFIX}")
-
-set(JSON_BuildTests OFF CACHE INTERNAL "")
-
-add_subdirectory("submodules/gularkfilesystem")
-add_subdirectory("submodules/json")
-
-find_package(CSpice REQUIRED)
-find_package(fmt REQUIRED)
-
-# Library setup
+# Variables required by multiple build options
 set(SUGARSPICE_BUILD_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/include/")
-set(SUGARSPICE_INSTALL_INCLUDE_DIR "include/SugarSpice")
-set(SUGARSPICE_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/utils.cpp
-                         ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/io.cpp
-                         ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/query.cpp
-                         ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/spice_types.cpp)
 
-set(SUGARSPICE_HEADER_FILES ${SUGARSPICE_BUILD_INCLUDE_DIR}/sugar_spice.h
-                            ${SUGARSPICE_BUILD_INCLUDE_DIR}/utils.h
-                            ${SUGARSPICE_BUILD_INCLUDE_DIR}/io.h
-                            ${SUGARSPICE_BUILD_INCLUDE_DIR}/spice_types.h
-                            ${SUGARSPICE_BUILD_INCLUDE_DIR}/query.h)
+#################
+# Library Build #
+#################
 
-set(SUGARSPICE_CONFIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/clem1.json
-                            ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/galileo.json
-                            ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/lro.json
-                            ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/mess.json)
+if(SUGARSPICE_BUILD_LIB)
 
-add_library(SugarSpice SHARED ${SUGARSPICE_SRC_FILES})
+  # Set a default build type if none was specified
+  set(default_build_type "Release")
+  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+        STRING "Choose the type of build." FORCE)
+  endif()
 
-ADD_DEFINITIONS(-D_SOURCE_PREFIX="${CMAKE_CURRENT_SOURCE_DIR}")
+  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
+  endif()
+  message(STATUS "Using install prefix: ${CMAKE_INSTALL_PREFIX}")
+
+  set(JSON_BuildTests OFF CACHE INTERNAL "")
+
+  add_subdirectory("submodules/gularkfilesystem")
+  add_subdirectory("submodules/json")
+
+  find_package(CSpice REQUIRED)
+  find_package(fmt REQUIRED)
+
+  # Library setup
+  set(SUGARSPICE_INSTALL_INCLUDE_DIR "include/SugarSpice")
+  set(SUGARSPICE_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/utils.cpp
+                          ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/io.cpp
+                          ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/query.cpp
+                          ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/src/spice_types.cpp)
+
+  set(SUGARSPICE_HEADER_FILES ${SUGARSPICE_BUILD_INCLUDE_DIR}/sugar_spice.h
+                              ${SUGARSPICE_BUILD_INCLUDE_DIR}/utils.h
+                              ${SUGARSPICE_BUILD_INCLUDE_DIR}/io.h
+                              ${SUGARSPICE_BUILD_INCLUDE_DIR}/spice_types.h
+                              ${SUGARSPICE_BUILD_INCLUDE_DIR}/query.h)
+
+  set(SUGARSPICE_CONFIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/clem1.json
+                              ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/galileo.json
+                              ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/lro.json
+                              ${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/db/mess.json)
+
+  add_library(SugarSpice SHARED ${SUGARSPICE_SRC_FILES})
+
+  ADD_DEFINITIONS(-D_SOURCE_PREFIX="${CMAKE_CURRENT_SOURCE_DIR}")
 
 
-set_target_properties(SugarSpice PROPERTIES
-                                 VERSION ${PROJECT_VERSION}
-                                 SOVERSION 0)
+  set_target_properties(SugarSpice PROPERTIES
+                                  VERSION ${PROJECT_VERSION}
+                                  SOVERSION 0)
 
-target_include_directories(SugarSpice
-                           PUBLIC
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/include>
-                           $<INSTALL_INTERFACE:include>
-                           PRIVATE)
+  target_include_directories(SugarSpice
+                            PUBLIC
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/SugarSpice/include>
+                            $<INSTALL_INTERFACE:include>
+                            PRIVATE)
 
-target_link_libraries(SugarSpice
-                      PUBLIC
-                      ghc_filesystem
-                      fmt::fmt-header-only
-                      nlohmann_json::nlohmann_json
-                      PRIVATE
-                      CSpice::cspice
-                      )
+  target_link_libraries(SugarSpice
+                        PUBLIC
+                        ghc_filesystem
+                        fmt::fmt-header-only
+                        nlohmann_json::nlohmann_json
+                        PRIVATE
+                        CSpice::cspice
+                        )
 
-install(TARGETS SugarSpice LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY ${SUGARSPICE_INCLUDE_DIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS SugarSpice LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(DIRECTORY ${SUGARSPICE_INCLUDE_DIR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-# Optional build tests
+  # Generate the package config
+  configure_file(cmake/config.cmake.in
+                ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+                @ONLY)
+
+  # Install the package config
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+  # Install the headers
+  install(FILES ${SUGARSPICE_HEADER_FILES} DESTINATION ${SUGARSPICE_INSTALL_INCLUDE_DIR})
+
+  # Install the json db files
+  install(FILES ${SUGARSPICE_CONFIG_FILES} DESTINATION "etc/SugarSpice/db")
+
+  # Install the library
+  install(TARGETS SugarSpice nlohmann_json
+          EXPORT sugarSpiceTargets
+          LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          INCLUDES DESTINATION ${SUGARSPICE_INSTALL_INCLUDE_DIR})
+
+  # Install the target
+  install(EXPORT sugarSpiceTargets
+          NAMESPACE spice::
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+else()
+  message(STATUS "Skipping Library")
+endif()
+
+###############
+# Tests Build #
+###############
+
 if(SUGARSPICE_BUILD_TESTS)
   include(GoogleTest)
   include(cmake/gtest.cmake)
@@ -90,35 +134,12 @@ else()
   message(STATUS "Skipping Tests")
 endif()
 
-# Setup Docs
+##############
+# Docs Build #
+##############
+
 if(SUGARSPICE_BUILD_DOCS)
   add_subdirectory ("docs")
 else()
   message(STATUS "Skipping Docs")
 endif()
-
-# Generate the package config
-configure_file(cmake/config.cmake.in
-               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-               @ONLY)
-
-# Install the package config
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-              DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-
-# Install the headers
-install(FILES ${SUGARSPICE_HEADER_FILES} DESTINATION ${SUGARSPICE_INSTALL_INCLUDE_DIR})
-
-# Install the json db files
-install(FILES ${SUGARSPICE_CONFIG_FILES} DESTINATION "etc/SugarSpice/db")
-
-# Install the library
-install(TARGETS SugarSpice nlohmann_json
-        EXPORT sugarSpiceTargets
-        LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        INCLUDES DESTINATION ${SUGARSPICE_INSTALL_INCLUDE_DIR})
-
-# Install the target
-install(EXPORT sugarSpiceTargets
-        NAMESPACE spice::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ make install
 # Optional, Run tests
 ctest -j8
 ```
+
+You can disable the documentation and/or test builds by setting the CMAKE variables `SUGARSPICE_BUILD_DOCS` and/or `SUGARSPICE_BUILD_TESTS` to `OFF`. For example, the following cmake configuration command will not build the documentation or the tests:
+
+```
+cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DSUGARSPICE_BUILD_DOCS=OFF -DSUGARSPICE_BUILD_TESTS=OFF
+```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ make install
 ctest -j8
 ```
 
-You can disable the documentation and/or test builds by setting the CMAKE variables `SUGARSPICE_BUILD_DOCS` and/or `SUGARSPICE_BUILD_TESTS` to `OFF`. For example, the following cmake configuration command will not build the documentation or the tests:
+You can disable the documentation or test builds by setting the CMAKE variables `SUGARSPICE_BUILD_DOCS` or `SUGARSPICE_BUILD_TESTS` to `OFF`. For example, the following cmake configuration command will not build the documentation or the tests:
 
 ```
 cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DSUGARSPICE_BUILD_DOCS=OFF -DSUGARSPICE_BUILD_TESTS=OFF

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ make install
 ctest -j8
 ```
 
-You can disable the documentation or test builds by setting the CMAKE variables `SUGARSPICE_BUILD_DOCS` or `SUGARSPICE_BUILD_TESTS` to `OFF`. For example, the following cmake configuration command will not build the documentation or the tests:
+You can disable different components of the build by setting the CMAKE variables `SUGARSPICE_BUILD_DOCS`, `SUGARSPICE_BUILD_TESTS`, or `SUGARSPICE_BUILD_LIB` to `OFF`. For example, the following cmake configuration command will not build the documentation or the tests:
 
 ```
 cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DSUGARSPICE_BUILD_DOCS=OFF -DSUGARSPICE_BUILD_TESTS=OFF


### PR DESCRIPTION
Added an option to not build the library and made the build tests option dependent upon it.

Updated the build docs with information about build options.

Moved the build options to the top of the CMake file as is standard.

Added a github action to build and check the docs. Also added installation tests to the github actions.

Related to #72