### PR TITLE
removed fs::path from headers

### DIFF
--- a/SugarSpice/include/io.h
+++ b/SugarSpice/include/io.h
@@ -1,14 +1,13 @@
 #pragma once
-/** 
+/**
  * @file
- * 
+ *
  * Functions for reading and writing Kernels
  *
  **/
 
 #include <string>
 #include <vector>
-#include <ghc/fs_std.hpp>
 
 #include <nlohmann/json.hpp>
 
@@ -61,7 +60,7 @@ namespace SugarSpice {
 
   class CkSegment {
       public:
-  
+
         /**
          * Constructs a fully populated SpkSegment
          * @param quats Time ordered vector of orientations as quaternions
@@ -72,21 +71,21 @@ namespace SugarSpice {
          * @param anglularVelocities Time ordered vector of state velocities dX, dY, dZ
          * @param comment The comment string for the new segment
          */
-        CkSegment(std::vector<std::vector<double>> quats, std::vector<double> times,  int bodyCode, 
-                  std::string referenceFrame, std::string id, 
-                  std::optional<std::vector<std::vector<double>>> anglularVelocities = std::nullopt, 
+        CkSegment(std::vector<std::vector<double>> quats, std::vector<double> times,  int bodyCode,
+                  std::string referenceFrame, std::string id,
+                  std::optional<std::vector<std::vector<double>>> anglularVelocities = std::nullopt,
                   std::optional<std::string> comment = std::nullopt);
-  
-        std::vector<double> times; 
-        std::vector<std::vector<double>> quats; 
-        int bodyCode; 
-        std::string referenceFrame; 
-        std::string id; 
-        std::optional<std::vector<std::vector<double>>> angularVelocities = std::nullopt; 
-        std::optional<std::string> comment = std::nullopt; 
+
+        std::vector<double> times;
+        std::vector<std::vector<double>> quats;
+        int bodyCode;
+        std::string referenceFrame;
+        std::string id;
+        std::optional<std::vector<std::vector<double>>> angularVelocities = std::nullopt;
+        std::optional<std::string> comment = std::nullopt;
     };
-  
-  
+
+
     /**
       * @brief Write SPK segments to a file
       *
@@ -95,14 +94,14 @@ namespace SugarSpice {
       * @param fileName file specification to have the SPK segments written to
       * @param segments spkSegments to be written
       */
-    void writeSpk (fs::path fileName,
+    void writeSpk (std::string fileName,
                    std::vector<SpkSegment> segments);
 
 
     /**
      * @brief Write SPK to path
-     * 
-     * @param fileName full path to file to write the segment to  
+     *
+     * @param fileName full path to file to write the segment to
      * @param statePositions Nx3 array of positions in X,Y,Z order
      * @param stateTimes Nx1 array of times
      * @param bodyCode NAIF integer code for the body the states belong to
@@ -113,13 +112,13 @@ namespace SugarSpice {
      * @param stateVelocities Nx3 array of state velocities in VX, VY, VZ order, optional
      * @param segmentComment Comment associated with the segment, optional
      */
-    void writeSpk(fs::path fileName, 
+    void writeSpk(std::string fileName,
                   std::vector<std::vector<double>> statePositions,
                   std::vector<double> stateTimes,
                   int bodyCode,
                   int centerOfMotion,
                   std::string referenceFrame,
-                  std::string segmentId, 
+                  std::string segmentId,
                   int polyDegree,
                   std::optional<std::vector<std::vector<double>>> stateVelocities = std::nullopt,
                   std::optional<std::string> segmentComment = std::nullopt);
@@ -128,53 +127,53 @@ namespace SugarSpice {
     /**
       * @brief Write CK segments to a file
       *
-      * Given orientations, angular velocities, times, target and reference frames, write data as a segment in a CK kernel. 
+      * Given orientations, angular velocities, times, target and reference frames, write data as a segment in a CK kernel.
       *
-      * @param fileName path to file to write the segment to 
-      * @param quats nx4 vector of orientations as quaternions 
+      * @param fileName path to file to write the segment to
+      * @param quats nx4 vector of orientations as quaternions
       * @param times nx1 vector of times matching the number of quats
-      * @param bodyCode NAIF body code identifying the orientations belong to 
-      * @param referenceFrame NAIF string for the reference frame the orientations are in 
-      * @param segmentId Some ID to give the segment 
-      * @param angularVelocity optional, nx3 array of angular velocities 
+      * @param bodyCode NAIF body code identifying the orientations belong to
+      * @param referenceFrame NAIF string for the reference frame the orientations are in
+      * @param segmentId Some ID to give the segment
+      * @param angularVelocity optional, nx3 array of angular velocities
       * @param comment optional, comment to be associated with the segment
       */
-    void writeCk(fs::path fileName, 
-                 std::vector<std::vector<double>> quats, 
-                 std::vector<double> times, 
-                 int bodyCode, 
-                 std::string referenceFrame, 
-                 std::string segmentId, 
-                 fs::path sclk, 
-                 fs::path lsk,
-                 std::optional<std::vector<std::vector<double>>> angularVelocity = std::nullopt, 
+    void writeCk(std::string fileName,
+                 std::vector<std::vector<double>> quats,
+                 std::vector<double> times,
+                 int bodyCode,
+                 std::string referenceFrame,
+                 std::string segmentId,
+                 std::string sclk,
+                 std::string lsk,
+                 std::optional<std::vector<std::vector<double>>> angularVelocity = std::nullopt,
                  std::optional<std::string> comment= std::nullopt);
-  
-  
+
+
     /**
      * @brief Write CK segments to a file
      *
-     * Given orientations, angular velocities, times, target and reference frames, write data as a segment in a CK kernel. 
+     * Given orientations, angular velocities, times, target and reference frames, write data as a segment in a CK kernel.
      *
-     * @param fileName path to file to write the segment to 
+     * @param fileName path to file to write the segment to
      * @param sclk path to SCLK kernel matching the segments' frame code
-     * @param lsk path to LSK kernel 
+     * @param lsk path to LSK kernel
      * @param segments spkSegments to be writte
      */
-  void writeCk(fs::path fileName, 
-               fs::path sclk, 
-               fs::path lsk,
+  void writeCk(std::string fileName,
+               std::string sclk,
+               std::string lsk,
                std::vector<CkSegment> segments);
 
 
   /**
    * @brief Write json key value pairs into a NAIF text kernel
-   *          
+   *
    * @param fileName pull path to the text kernel
    * @param type kernel type string, valid text kernel types: FK, IK, LSK, MK, PCK, SCLK
-   * @param comment the comment to add to the top of the kernel 
+   * @param comment the comment to add to the top of the kernel
    * @param keywords json object containing key/value pairs to write to the text kernel
    */
-  void writeTextKernel(fs::path fileName, std::string type, nlohmann::json &keywords, std::optional<std::string> comment = std::nullopt);
-  
+  void writeTextKernel(std::string fileName, std::string type, nlohmann::json &keywords, std::optional<std::string> comment = std::nullopt);
+
   }

--- a/SugarSpice/include/query.h
+++ b/SugarSpice/include/query.h
@@ -1,8 +1,8 @@
-#pragma once 
-/** 
-  * @file 
-  * 
-  * Functions that interigate the user's kernel installation to return kernels lists 
+#pragma once
+/**
+  * @file
+  *
+  * Functions that interigate the user's kernel installation to return kernels lists
   * or SPICE information are located here
   *
  **/
@@ -10,79 +10,78 @@
 #include <vector>
 #include <iostream>
 #include <nlohmann/json.hpp>
-#include <ghc/fs_std.hpp>
 
 
 namespace SugarSpice {
-  /** 
-    * @brief get the latest kernel in a list 
-    *  
-    * Returns the kernel with the latest version string (e.g. the highest v??? or similar
-    * sub-string in a kernel path name) in the input list and returns it as a path object.   
+  /**
+    * @brief get the latest kernel in a list
     *
-    * @param kernels vector of strings, should be a list of kernel paths. 
-    * @returns path object to latest Kernel 
+    * Returns the kernel with the latest version string (e.g. the highest v??? or similar
+    * sub-string in a kernel path name) in the input list and returns it as a path object.
+    *
+    * @param kernels vector of strings, should be a list of kernel paths.
+    * @returns path object to latest Kernel
    **/
-  fs::path getLatestKernel(std::vector<std::string> kernels);
-  
+  std::string getLatestKernel(std::vector<std::string> kernels);
 
-   /** 
+
+   /**
     * @brief returns a JSON object of only the latest version of each kernel type
-    *  
-    * Recursively iterates Kernel groups in the input JSON and gets the kernels 
-    * with the latest version string (e.g. the highest v??? sub-string in a kernel path name). 
-    * 
-    * New JSON is returned. 
-    * 
-    * @param kernels A Kernel JSON object 
-    * @returns A new Kernel JSON object with reduced kernel sets 
-   **/  
+    *
+    * Recursively iterates Kernel groups in the input JSON and gets the kernels
+    * with the latest version string (e.g. the highest v??? sub-string in a kernel path name).
+    *
+    * New JSON is returned.
+    *
+    * @param kernels A Kernel JSON object
+    * @returns A new Kernel JSON object with reduced kernel sets
+   **/
   nlohmann::json getLatestKernels(nlohmann::json kernels);
 
 
   /**
    * @brief Returns all kernels available for a mission
    *
-   * Returns a structured json object containing all available kernels for a specified mission 
+   * Returns a structured json object containing all available kernels for a specified mission
    * along with their dependencies.
-   *  
-   * TODO: Add a "See Also" on json format after the format matures a bit more. 
    *
-   * @param root root path to search 
-   * @param conf json conf file 
+   * TODO: Add a "See Also" on json format after the format matures a bit more.
+   *
+   * @param root root path to search
+   * @param conf json conf file
    * @returns list of paths matching ext
   **/
-  nlohmann::json searchMissionKernels(fs::path root,  nlohmann::json conf);
-  
-  
+  nlohmann::json searchMissionKernels(std::string root,  nlohmann::json conf);
+
+
   /**
-   * @brief Returns all kernels available in the time range 
+   * @brief Returns all kernels available in the time range
    *
-   * Returns a structured json object containing all available kernels for a specified time  
+   * Returns a structured json object containing all available kernels for a specified time
    * range along with their dependencies.
-   *  
-   * TODO: Add a "See Also" on json format after the format matures a bit more. 
    *
-   * @param kernels kernels to search 
-   * @param times vector of times to match 
-   * @param isContiguous if true, all times need to be in the kernel to match the query, else, any kernel that 
-   *                     is in any of the times inputed get returned 
-   * @returns json object with new kernels 
+   * TODO: Add a "See Also" on json format after the format matures a bit more.
+   *
+   * @param kernels kernels to search
+   * @param times vector of times to match
+   * @param isContiguous if true, all times need to be in the kernel to match the query, else, any kernel that
+   *                     is in any of the times inputed get returned
+   * @returns json object with new kernels
   **/
   nlohmann::json searchMissionKernels(nlohmann::json kernels, std::vector<double> times, bool isContiguous=false);
-  
-  
+
+
   /**
-    * @brief acquire all kernels of a type according to a configuration JSON object 
-    * 
-    * Given the root directotry with kernels, a JSON configuration object and a kernel type string (e.g. ck, fk, spk), 
-    * return a JSON object containing kernels. The kernel config's regular expressions 
-    * are replaced by a concrete kernel list located in the passed in root. 
+    * @brief acquire all kernels of a type according to a configuration JSON object
     *
-    * @param root Directory with kernels somewhere in the directory or its subdirectories 
-    * @param conf JSON config file, usually this is a JSON object read from one of the db files that shipped with the library 
+    * Given the root directotry with kernels, a JSON configuration object and a kernel type string (e.g. ck, fk, spk),
+    * return a JSON object containing kernels. The kernel config's regular expressions
+    * are replaced by a concrete kernel list located in the passed in root.
+    *
+    * @param root Directory with kernels somewhere in the directory or its subdirectories
+    * @param conf JSON config file, usually this is a JSON object read from one of the db files that shipped with the library
     * @param kernelType Some CK kernel type, see Kernel::TYPES
    **/
-  nlohmann::json globKernels(fs::path root, nlohmann::json conf, std::string kernelType);
+  nlohmann::json globKernels(std::string root, nlohmann::json conf, std::string kernelType);
 
 }

--- a/SugarSpice/include/spice_types.h
+++ b/SugarSpice/include/spice_types.h
@@ -1,48 +1,47 @@
-#pragma once 
+#pragma once
 
-/** 
+/**
   *
   *
  **/
 
-#include <ghc/fs_std.hpp>
 #include <iostream>
 
 namespace SugarSpice {
 
   /**
-   * @brief Base Kernel class 
-   * 
-   * This is mostly designed to enable the automatic unloading 
-   * of kernels. The kernel is furnsh-ed on instantiation and 
-   * unloaded in the destructor. 
-   * 
+   * @brief Base Kernel class
+   *
+   * This is mostly designed to enable the automatic unloading
+   * of kernels. The kernel is furnsh-ed on instantiation and
+   * unloaded in the destructor.
+   *
    */
   class Kernel {
-      public: 
+      public:
 
       /**
-       * @brief Enumeration representing the different possible kernel types 
+       * @brief Enumeration representing the different possible kernel types
        **/
       enum class Type { NA=0,
-        CK, SPK, TSPK, 
+        CK, SPK, TSPK,
         LSK, MK, SCLK,
-        IAK, IK, FK, 
+        IAK, IK, FK,
         DSK, PCK, EK
-      }; 
+      };
 
       /**
-       * @brief Enumeration representing the different possible kernel qualities 
-       **/ 
+       * @brief Enumeration representing the different possible kernel qualities
+       **/
       enum class Quality  {
-        PREDICTED = 1,     // Based on predicted future location of the spacecraft/body     
-        NADIR = 2,         // Assumes Nadir pointing   
+        PREDICTED = 1,     // Based on predicted future location of the spacecraft/body
+        NADIR = 2,         // Assumes Nadir pointing
         RECONSTRUCTED = 3, // Supplemented by real spacecraft/body data
         SMITHED = 4,       // Controlled Kernels
-        NA = SMITHED       // Either Quaility doesn't apply (e.g. text kernels) -or- 
+        NA = SMITHED       // Either Quaility doesn't apply (e.g. text kernels) -or-
                            // we dont care about quality (e.g. CK of any quality)
       };
-      
+
       const static std::vector<std::string> QUALITIES;
       const static std::vector<std::string> TYPES;
 
@@ -60,7 +59,7 @@ namespace SugarSpice {
        * @brief Switch between Kernel type string to enum
        *
        * @param type String to translate to a Kernel::Type, must be all lower case
-       * @return Kernel::Type representation of the kernel type, eg. "ck" returns Kernel::Type::CK 
+       * @return Kernel::Type representation of the kernel type, eg. "ck" returns Kernel::Type::CK
        **/
       static Type translateType(std::string type);
 
@@ -69,11 +68,11 @@ namespace SugarSpice {
        * @brief Switch between Quality enum to string
        *
        * @param qa Kernel::Quality to translate to a string
-       * @return String representation of the kernel type, eg. Kernel::Quality::Reconstructed  returns "reconstructed" 
-       **/ 
+       * @return String representation of the kernel type, eg. Kernel::Quality::Reconstructed  returns "reconstructed"
+       **/
       static std::string translateQuality(Quality qa);
-      
-      
+
+
       /**
        * @brief Switch between Kernel quality string to enum
        *
@@ -85,78 +84,78 @@ namespace SugarSpice {
 
       /**
        * @brief Switch between NAIF frame string code to integer frame code
-       *  
+       *
        * See <a href="https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/naif_ids.html">NAIF's Docs on frame codes</a> for more information
-       * 
+       *
        * @param frame String to translate to a NAIF code
        * @return integer Naif frame code
        **/
-      static int translateFrame(std::string frame); 
+      static int translateFrame(std::string frame);
 
 
       /**
        * @brief Switch between NAIF frame integer code to string frame code
-       *  
+       *
        * See <a href="https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/naif_ids.html">NAIF's Docs on frame codes</a> for more information
-       * 
+       *
        * @param frame int NAIF frame code to translate
        * @return Translated string frame code
-       **/   
-      static std::string translateFrame(int frame); 
+       **/
+      static std::string translateFrame(int frame);
 
 
       /**
-        * @brief Instantiate a kernel from path 
+        * @brief Instantiate a kernel from path
         *
-        * Load a kernel into memory by opening the kernel and furnishing 
+        * Load a kernel into memory by opening the kernel and furnishing
         *
-        * @param path path to a kernel. 
-        * 
+        * @param path path to a kernel.
+        *
       **/
-      Kernel(fs::path path);
-      
+      Kernel(std::string path);
+
 
       /**
-        * @brief unfurnsh the kernel 
+        * @brief unfurnsh the kernel
         *
-        * Delete a kernel from memory by deleting the object and unfurnshing. 
-        * 
+        * Delete a kernel from memory by deleting the object and unfurnshing.
+        *
       **/
-      ~Kernel();    
+      ~Kernel();
 
-      fs::path path;   // path to the kernel 
+      std::string path;   // path to the kernel
       Type type;       // type of kernel
       Quality quality; // quality of the kernel
   };
 
 
   /**
-   * @brief typedef of std::shared_ptr<Kernel> 
-   * 
-   * This basically allows the Kernel to exist as a reference counted 
-   * variable. Once all references to the Kernel cease to exist, the kernel 
-   * is unloaded. 
+   * @brief typedef of std::shared_ptr<Kernel>
+   *
+   * This basically allows the Kernel to exist as a reference counted
+   * variable. Once all references to the Kernel cease to exist, the kernel
+   * is unloaded.
    */
   typedef std::shared_ptr<Kernel> SharedKernel;
 
 
   /**
-   * @brief typedef of std::unique_ptr<Kernel> 
-   * 
-   * This basically allows the Kernel to exist only within the 
-   * call stack it is used in. 
+   * @brief typedef of std::unique_ptr<Kernel>
+   *
+   * This basically allows the Kernel to exist only within the
+   * call stack it is used in.
    */
   typedef std::unique_ptr<Kernel> StackKernel;
 
 
   /**
    * @brief convert a UTC string to an ephemeris time
-   *  
-   * Basically a wrapper around NAIF's cspice str2et function except it also temporarily loads the required kernels. 
+   *
+   * Basically a wrapper around NAIF's cspice str2et function except it also temporarily loads the required kernels.
    * See Also: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html
    *
    * @param et UTC string, e.g. "1988 June 13, 12:29:48 TDB"
-   * @returns double precision ephemeris time 
+   * @returns double precision ephemeris time
    **/
   double utcToEt(std::string et);
 }

--- a/SugarSpice/include/utils.h
+++ b/SugarSpice/include/utils.h
@@ -15,29 +15,27 @@
 
 #include <nlohmann/json.hpp>
 
-#include <ghc/fs_std.hpp>
-
 #include "spice_types.h"
 
 namespace SugarSpice {
-  
+
   /**
    * @brief force a string to upper case
-   * 
+   *
    * @param s input string
    * @return copy of input string, in upper case
    */
   std::string toUpper(std::string s);
-  
+
 
   /**
    * @brief force a string to lower case
-   * 
+   *
    * @param s input string
    * @return copy of input string, in lower case
    */
   std::string toLower(std::string s);
-  
+
 
   /**
    * @brief find and replace one substring with another
@@ -45,102 +43,102 @@ namespace SugarSpice {
    * @param str input string to search
    * @param from substring to find
    * @param to substring to replace "from" instances to
-   * @return std::string 
+   * @return std::string
    */
   std::string replaceAll(std::string str, const std::string &from, const std::string &to);
-  
-  
+
+
   /**
     * @brief ls, like in unix, kinda. Also it's a function.
     *
-    * Iterates the input path and returning a list of files. Optionally, recursively. 
+    * Iterates the input path and returning a list of files. Optionally, recursively.
     *
-    * @param root The root directory to search 
-    * @param recursive recursively iterates through directories if true 
-    * 
+    * @param root The root directory to search
+    * @param recursive recursively iterates through directories if true
+    *
     * @returns list of paths
    **/
-  std::vector<fs::path> ls(fs::path const & root, bool recursive);
-  
-  
+  std::vector<std::string> ls(std::string const & root, bool recursive);
+
+
   /**
     * @brief glob, like python's glob.glob, except C++
     *
-    * Given a root and a regular expression, give all the files that match.  
+    * Given a root and a regular expression, give all the files that match.
     *
-    * @param root The root directory to search 
-    * @param reg std::regex object to pattern to search, defaults to ".*", or match averything.  
-    * @param recursive recursively iterates through directories if true 
-    * 
+    * @param root The root directory to search
+    * @param reg std::regex object to pattern to search, defaults to ".*", or match averything.
+    * @param recursive recursively iterates through directories if true
+    *
     * @returns list of paths matching regex
    **/
-  std::vector<fs::path> glob(fs::path const & root, 
-                             std::regex const & reg = std::regex(".*"), 
+  std::vector<std::string> glob(std::string const & root,
+                             std::regex const & reg = std::regex(".*"),
                              bool recursive=false);
-  
-  
+
+
   /**
-    * @brief Get start and stop times a kernel. 
+    * @brief Get start and stop times a kernel.
     *
-    * For each segment in the kernel, get all start and stop times as a vector of double pairs. 
+    * For each segment in the kernel, get all start and stop times as a vector of double pairs.
     * This gets all start and stop times regardless of the frame associated with it.
-    * 
-    * Input kernel is assumed to be a binary kernel with time dependant external orientation data. 
-    * 
-    * @param kpath Path to the kernel 
-    * @returns std::vector of start and stop times  
+    *
+    * Input kernel is assumed to be a binary kernel with time dependant external orientation data.
+    *
+    * @param kpath Path to the kernel
+    * @returns std::vector of start and stop times
    **/
-  std::vector<std::pair<double, double>> getTimeIntervals(fs::path kpath);
+  std::vector<std::pair<double, double>> getTimeIntervals(std::string kpath);
 
 
   /**
-   * @brief Simple struct for holding target states  
+   * @brief Simple struct for holding target states
    */
   struct targetState {double lt; std::array<double,6> starg;};
 
 
   /**
    * @brief Gives the position and velocity for a given frame at some ephemeris time
-   * 
-   * Mostly a C++ wrap for NAIF's spkezr_c 
-   * 
-   * @param et ephemeris time at which you want to optain the target state 
-   * @param target NAIF ID for the target frame 
-   * @param observer NAIF ID for the observing frame 
-   * @param frame The reference frame in which to get the positions in 
-   * @param abcorr aborration correction flag, default it NONE. 
-   *        This can set to:           
-   *           "NONE" - No correction 
-   *        For the "reception" case, i.e. photons from the target being recieved by the observer at the given time.           
-   *           "LT"   - One way light time correction 
-   *           "LT+S" - Correct for one-way light time and stellar aberration correction 
+   *
+   * Mostly a C++ wrap for NAIF's spkezr_c
+   *
+   * @param et ephemeris time at which you want to optain the target state
+   * @param target NAIF ID for the target frame
+   * @param observer NAIF ID for the observing frame
+   * @param frame The reference frame in which to get the positions in
+   * @param abcorr aborration correction flag, default it NONE.
+   *        This can set to:
+   *           "NONE" - No correction
+   *        For the "reception" case, i.e. photons from the target being recieved by the observer at the given time.
+   *           "LT"   - One way light time correction
+   *           "LT+S" - Correct for one-way light time and stellar aberration correction
    *           "CN"   - Converging Newtonian light time correction
-   *           "CN+S" - Converged Newtonian light time correction and stellar aberration correction  
-   *        For the "transmission" case, i.e. photons emitted from the oberver hitting at target at the given time  
-   *           "XLT"   - One-way light time correction using a newtonian formulation  
-   *           "XLT+S" - One-way light time and stellar aberration correction using a newtonian formulation  
+   *           "CN+S" - Converged Newtonian light time correction and stellar aberration correction
+   *        For the "transmission" case, i.e. photons emitted from the oberver hitting at target at the given time
+   *           "XLT"   - One-way light time correction using a newtonian formulation
+   *           "XLT+S" - One-way light time and stellar aberration correction using a newtonian formulation
    *           "XCN"   - converged Newtonian light time correction
    *           "XCN+S" - converged Newtonian light time correction and stellar aberration correction.
-   *  @return A TargetState struct with the light time adjustment and a Nx6 state vector of positions and velocities in x,y,z,vx,vy,vz format.   
+   *  @return A TargetState struct with the light time adjustment and a Nx6 state vector of positions and velocities in x,y,z,vx,vy,vz format.
   **/
   targetState getTargetState(double et, std::string target, std::string observer, std::string frame="J2000", std::string abcorr="NONE");
 
 
   /**
-   * @brief simple struct for holding target orientations 
+   * @brief simple struct for holding target orientations
    */
   struct targetOrientation {std::array<double,4> quat; std::optional<std::array<double,3>> av;};
 
 
   /**
    * @brief Gives quaternion and angular velocity for a given frame at a given ephemeris time
-   * 
-   * Orientations for an input frame in some reference frame. 
+   *
+   * Orientations for an input frame in some reference frame.
    * The orientations returned from this function can be used to transform a position
-   * in the source frame to the ref frame. 
-   * 
-   * @param et ephemeris time at which you want to optain the target pointing 
-   * @param toframe the source frame's NAIF code. 
+   * in the source frame to the ref frame.
+   *
+   * @param et ephemeris time at which you want to optain the target pointing
+   * @param toframe the source frame's NAIF code.
    * @param refframe the reference frame's NAIF code, orientations are relative to this reference frame
    * @returns SPICE-style quaternions (w,x,y,z) and optional angular velocity
   **/
@@ -154,106 +152,106 @@ namespace SugarSpice {
     *   by using gnpool, gcpool, gdpool, and gipool
     *
     * @param keytpl input key template to search for
-    * 
+    *
     * @returns json list of found key:values
    **/
   nlohmann::json findKeywords(std::string keytpl);
 
-  
+
   /**
-    * @brief recursively search keys in json. 
+    * @brief recursively search keys in json.
     *
-    * Given a root and a regular expression, give all the files that match.  
+    * Given a root and a regular expression, give all the files that match.
     *
     * @param in input json to search
-    * @param key key to search for   
-    * @param recursive recursively iterates through objects if true 
-    * 
-    * @returns vector of refernces to matching json objects 
+    * @param key key to search for
+    * @param recursive recursively iterates through objects if true
+    *
+    * @returns vector of refernces to matching json objects
    **/
   std::vector<nlohmann::json::json_pointer> findKeyInJson(nlohmann::json in, std::string key, bool recursive=true);
-  
+
 
   /**
     * @brief This is a short description
     *
-    * This is a long description 
+    * This is a long description
     *
-    * @param kpath The root directory to search 
+    * @param kpath The root directory to search
     * @param sclk  Required sclk kernel
     * @param lsk   Required lsk kernel
-    * 
+    *
     * @returns list of paths matching ext
    **/
   std::vector<std::pair<std::string, std::string>> getCkIntervals(std::string kpath, std::string sclk, std::string lsk);
-  
-  
-  /** 
-    * @brief get the Kernel type (CK, SPK, etc.) 
-    * 
+
+
+  /**
+    * @brief get the Kernel type (CK, SPK, etc.)
     *
-    * @param kernelPath path to kernel 
-    * @returns Kernel type as a string 
+    *
+    * @param kernelPath path to kernel
+    * @returns Kernel type as a string
    **/
-   std::string getKernelType(fs::path kernelPath);
-  
-  
-  /** 
-    * @brief Returns the path to the Mission specific Spice config file. 
-    * 
-    * Given a mission, search a prioritized list of directories for 
-    * the json config file. This function checks in the order: 
-    *  
+   std::string getKernelType(std::string kernelPath);
+
+
+  /**
+    * @brief Returns the path to the Mission specific Spice config file.
+    *
+    * Given a mission, search a prioritized list of directories for
+    * the json config file. This function checks in the order:
+    *
     *   1. The local build dir, i.e. $CMAKE_SOURCE_DIR
-    *   2. The install dir, i.e. $CMAKE_PREFIX 
-    * 
-    * @param mission mission name of the config file 
-    * 
+    *   2. The install dir, i.e. $CMAKE_PREFIX
+    *
+    * @param mission mission name of the config file
+    *
     * @returns path object of the condig file
    **/
-   fs::path getMissionConfigFile(std::string mission);
-  
-  
-  /** 
-    * @brief Returns the path to the Mission specific Spice config file. 
-    * 
-    * Given a mission, search a prioritized list of directories for 
-    * the json config file. This function checks in the order: 
-    *  
+   std::string getMissionConfigFile(std::string mission);
+
+
+  /**
+    * @brief Returns the path to the Mission specific Spice config file.
+    *
+    * Given a mission, search a prioritized list of directories for
+    * the json config file. This function checks in the order:
+    *
     *   1. The local build dir, i.e. $CMAKE_SOURCE_DIR
-    *   2. The install dir, i.e. $CMAKE_PREFIX 
-    * 
-    * @param mission mission name of the config file 
-    * 
+    *   2. The install dir, i.e. $CMAKE_PREFIX
+    *
+    * @param mission mission name of the config file
+    *
     * @returns path object of the condig file
-   **/ 
-   nlohmann::json getMissionConfig(std::string mission); 
-  
-  
-  /** 
-    * @brief Returns std::vector<string> interpretation of a json array. 
-    * 
-    * Attempts to convert the json array to a C++ array. Also handles 
-    * strings in cases where one element arrays are stored as scalars. 
-    * Throws exception if the json obj is not an array. 
-    * 
+   **/
+   nlohmann::json getMissionConfig(std::string mission);
+
+
+  /**
+    * @brief Returns std::vector<string> interpretation of a json array.
+    *
+    * Attempts to convert the json array to a C++ array. Also handles
+    * strings in cases where one element arrays are stored as scalars.
+    * Throws exception if the json obj is not an array.
+    *
     * @param arr input json arr
-    * 
+    *
     * @returns string vector containing arr data
-   **/ 
+   **/
    std::vector<std::string> jsonArrayToVector(nlohmann::json arr);
-  
-  
-  /** 
-    * @brief Returns std::vector<string> interpretation of a json array. 
-    * 
-    * Attempts to convert the json array to a C++ array. Also handles 
-    * strings in cases where one element arrays are stored as scalars. 
-    * Throws exception if the json obj is not an array. 
-    * 
+
+
+  /**
+    * @brief Returns std::vector<string> interpretation of a json array.
+    *
+    * Attempts to convert the json array to a C++ array. Also handles
+    * strings in cases where one element arrays are stored as scalars.
+    * Throws exception if the json obj is not an array.
+    *
     * @param arr input json arr
-    * 
+    *
     * @returns string vector containing arr data
-   **/ 
-   fs::path getDataDirectory();
+   **/
+   std::string getDataDirectory();
 }

--- a/SugarSpice/src/io.cpp
+++ b/SugarSpice/src/io.cpp
@@ -8,7 +8,7 @@
 #include "utils.h"
 
 
-using namespace std; 
+using namespace std;
 
 using json = nlohmann::json;
 
@@ -55,14 +55,14 @@ namespace SugarSpice {
   }
 
 
-  CkSegment::CkSegment(vector<vector<double>> quats, 
-                       vector<double> times, 
-                       int bodyCode, 
-                       string referenceFrame, 
+  CkSegment::CkSegment(vector<vector<double>> quats,
+                       vector<double> times,
+                       int bodyCode,
+                       string referenceFrame,
                        string segmentId,
-                       optional<vector<vector<double>>> anglularVelocities, 
+                       optional<vector<vector<double>>> anglularVelocities,
                        optional<string> comment) {
-      
+
     this->comment            = comment;
     this->bodyCode           = bodyCode;
     this->referenceFrame     = referenceFrame;
@@ -72,56 +72,56 @@ namespace SugarSpice {
   }
 
 
-  void writeCk(fs::path path, 
-               vector<vector<double>> quats, 
-               vector<double> times, 
-               int bodyCode, 
-               string referenceFrame, 
-               string segmentId, 
-               fs::path sclk, 
-               fs::path lsk,
-               optional<vector<vector<double>>> angularVelocities, 
-               optional<string> comment) {                 
+  void writeCk(string path,
+               vector<vector<double>> quats,
+               vector<double> times,
+               int bodyCode,
+               string referenceFrame,
+               string segmentId,
+               string sclk,
+               string lsk,
+               optional<vector<vector<double>>> angularVelocities,
+               optional<string> comment) {
 
-    SpiceInt handle; 
+    SpiceInt handle;
 
     // convert times, but first, we need SCLK+LSK kernels
     unique_ptr<Kernel> sclkKernel(new Kernel(sclk));
     unique_ptr<Kernel> lskKernel(new Kernel(lsk));
 
     for(auto &et : times) {
-      double sclkdp; 
+      double sclkdp;
       sce2c_c(bodyCode/1000, et, &sclkdp);
-      et = sclkdp; 
+      et = sclkdp;
     }
 
     ckopn_c(path.c_str(), "CK", comment.value_or("CK Kernel").size(), &handle);
 
-    ckw03_c (handle, 
+    ckw03_c (handle,
              times.at(0),
              times.at(times.size()-1),
              bodyCode,
              referenceFrame.c_str(),
              (bool)angularVelocities,
-             segmentId.c_str(), 
+             segmentId.c_str(),
              times.size(),
              times.data(),
              quats.data(),
              (angularVelocities) ? angularVelocities->data() : nullptr,
              times.size(),
              times.data());
-    
+
     ckcls_c(handle);
   }
 
 
-  void writeSpk(fs::path fileName, 
+  void writeSpk(string fileName,
                  vector<vector<double>> statePositions,
                  vector<double> stateTimes,
                  int bodyCode,
                  int centerOfMotion,
                  string referenceFrame,
-                 string segmentId, 
+                 string segmentId,
                  int polyDegree,
                  optional<vector<vector<double>>> stateVelocities,
                  optional<string> segmentComment) {
@@ -129,19 +129,19 @@ namespace SugarSpice {
     vector<vector<double>> states;
 
     if (!stateVelocities) {
-      // init a 0 velocity array 
+      // init a 0 velocity array
       vector<vector<double>> velocities;
-      for (int i = 0; i < statePositions.size(); i++) { 
+      for (int i = 0; i < statePositions.size(); i++) {
         velocities.push_back({0,0,0});
       }
       stateVelocities = velocities;
     }
-    
+
     states = concatStates(statePositions, *stateVelocities);
 
     SpiceInt handle;
-    spkopn_c(fileName.string().c_str(), "SPK", 512, &handle);
-    
+    spkopn_c(fileName.c_str(), "SPK", 512, &handle);
+
     spkw13_c(handle,
              bodyCode,
              centerOfMotion,
@@ -160,7 +160,7 @@ namespace SugarSpice {
   }
 
 
-  void writeSpk(fs::path fileName, vector<SpkSegment> segments) {
+  void writeSpk(string fileName, vector<SpkSegment> segments) {
 
     // TODO:
     //   write all segments not just first
@@ -169,10 +169,10 @@ namespace SugarSpice {
     //   Add convience function to SpkSegment to combine the pos and vel into a single array
 
     // Combine positions and velocities for spicelib call
-    
+
     writeSpk(fileName,
              segments[0].statePositions,
-             segments[0].stateTimes, 
+             segments[0].stateTimes,
              segments[0].bodyCode,
              segments[0].centerOfMotion,
              segments[0].referenceFrame,
@@ -184,7 +184,7 @@ namespace SugarSpice {
     return;
   }
 
-  void writeCk(fs::path fileName, fs::path sclk, fs::path lsk, vector<CkSegment> segments) {
+  void writeCk(string fileName, string sclk, string lsk, vector<CkSegment> segments) {
 
     // TODO:
     //   write all segments not just first
@@ -193,101 +193,101 @@ namespace SugarSpice {
     //   Add convience function to SpkSegment to combine the pos and vel into a single array
 
     // Combine positions and velocities for spicelib call
-    
+
     writeCk(fileName,
             segments[0].quats,
-            segments[0].times, 
+            segments[0].times,
             segments[0].bodyCode,
             segments[0].referenceFrame,
             segments[0].id,
-            sclk, 
+            sclk,
             lsk,
             segments[0].angularVelocities,
             segments[0].comment);
 
   }
-  
 
-  void writeTextKernel(fs::path fileName, string type, json &keywords, optional<string> comment) { 
+
+  void writeTextKernel(string fileName, string type, json &keywords, optional<string> comment) {
 
     /**
-     * @brief Return an adjusted string such that it multi-lined if longer than some max length. 
+     * @brief Return an adjusted string such that it multi-lined if longer than some max length.
      *
-     * This generates a string that is compatible with the requirements my NAIF text kernels 
-     * to be multi-line. 
+     * This generates a string that is compatible with the requirements my NAIF text kernels
+     * to be multi-line.
      */
-    auto adjustStringLengths = [](string s, size_t maxLen = 100, bool isComment = true) -> string {         
-      // first, escape single quotes 
+    auto adjustStringLengths = [](string s, size_t maxLen = 100, bool isComment = true) -> string {
+      // first, escape single quotes
       s = replaceAll(s, "'", "''");
 
-      if (s.size() <= maxLen && isComment) {          
+      if (s.size() <= maxLen && isComment) {
         return s;
       }
-      else if (s.size() <= maxLen - 5 && !isComment) { 
+      else if (s.size() <= maxLen - 5 && !isComment) {
         return "( '" + s + "' )";
       }
 
-      string newString; 
+      string newString;
       string formatString = (isComment) ? "{}\n" : "( '{}' // )";
-      
-      for(int i = 0; i < s.size()/maxLen; i++) { 
+
+      for(int i = 0; i < s.size()/maxLen; i++) {
         newString.append(fmt::format(formatString, s.substr(i*maxLen, maxLen)) + "\n");
       }
       newString.append(fmt::format(formatString, s.substr(s.size()-(s.size()%maxLen), s.size()%maxLen)));
 
-      return newString; 
+      return newString;
     };
 
     /**
      * @brief Given a JSON primitive, return a text kernel freindly string representation
      */
     auto json2String = [&](json keyword, size_t maxStrLen) -> string {
-        if (!keyword.is_primitive()) {            
+        if (!keyword.is_primitive()) {
           throw invalid_argument("Input JSON must be a primitive, not an array or object.");
         }
 
         if(keyword.is_string()) {
-          return adjustStringLengths(keyword.get<string>(), maxStrLen, false); 
+          return adjustStringLengths(keyword.get<string>(), maxStrLen, false);
         }
         if(keyword.is_number_integer()) {
-          return to_string(keyword.get<int>());  
+          return to_string(keyword.get<int>());
         }
         if(keyword.is_number_float()) {
-          return to_string(keyword.get<double>());  
+          return to_string(keyword.get<double>());
         }
         if(keyword.is_boolean()) {
-          return (keyword.get<bool>()) ? "'true'" : "'false'";  
+          return (keyword.get<bool>()) ? "'true'" : "'false'";
         }
         if(keyword.is_null()) {
-          return "'null'";  
-        } 
-        
-        // theoritically should never throw 
-        throw invalid_argument("in json2string, input keyword is not a viable primitive type.");
-    };            
+          return "'null'";
+        }
 
-    static unsigned int MAX_TEXT_KERNEL_LINE_LEN = 132; 
+        // theoritically should never throw
+        throw invalid_argument("in json2string, input keyword is not a viable primitive type.");
+    };
+
+    static unsigned int MAX_TEXT_KERNEL_LINE_LEN = 132;
 
     ofstream textKernel;
     textKernel.open(fileName);
     string typeUpper = toUpper(type);
     vector<string> supportedTextKernels = {"FK", "IK", "LSK", "MK", "PCK", "SCLK"};
-    
+
     if (std::find(supportedTextKernels.begin(), supportedTextKernels.end(), typeUpper) == supportedTextKernels.end()) {
-      throw invalid_argument(fmt::format("{} is not a valid text kernel type", type));  
+      throw invalid_argument(fmt::format("{} is not a valid text kernel type", type));
     }
-    
+
     textKernel << "KPL/" + toUpper(type) << endl << endl;
     textKernel << "\\begintext" << endl << endl;
     textKernel << comment.value_or("") << endl << endl;
     textKernel << "\\begindata" << endl << endl;
 
     for(auto it = keywords.begin(); it != keywords.end(); it++) {
-      
-      if (it.value().is_array()) {            
-        textKernel << fmt::format("{} = {}",  it.key(), json2String(it.value().at(0), MAX_TEXT_KERNEL_LINE_LEN - it.key().size() + 5)) << endl; 
-        for(auto ar = it.value().begin()+1; ar!=it.value().end();ar++) { 
-          textKernel << fmt::format("{} += {}", it.key(), json2String(ar.value(),  MAX_TEXT_KERNEL_LINE_LEN - it.key().size() + 5)) << endl;  
+
+      if (it.value().is_array()) {
+        textKernel << fmt::format("{} = {}",  it.key(), json2String(it.value().at(0), MAX_TEXT_KERNEL_LINE_LEN - it.key().size() + 5)) << endl;
+        for(auto ar = it.value().begin()+1; ar!=it.value().end();ar++) {
+          textKernel << fmt::format("{} += {}", it.key(), json2String(ar.value(),  MAX_TEXT_KERNEL_LINE_LEN - it.key().size() + 5)) << endl;
         }
       }
       else if(it.value().is_primitive()) {
@@ -301,5 +301,5 @@ namespace SugarSpice {
 
     textKernel.close();
   }
-  
+
 }

--- a/SugarSpice/src/query.cpp
+++ b/SugarSpice/src/query.cpp
@@ -11,6 +11,9 @@
 
 #include <SpiceUsr.h>
 
+
+#include <ghc/fs_std.hpp>
+
 #include "query.h"
 #include "spice_types.h"
 #include "utils.h"
@@ -19,8 +22,8 @@ using json = nlohmann::json;
 using namespace std;
 
 namespace SugarSpice {
-  
-  fs::path getLatestKernel(vector<string> kernels) {
+
+  string getLatestKernel(vector<string> kernels) {
     string extension = static_cast<fs::path>(kernels.at(0)).extension();
     // ensure everything is different versions of the same file
     for(const fs::path &k : kernels) {
@@ -28,32 +31,32 @@ namespace SugarSpice {
         throw invalid_argument("The input paths do are not different versions of the same file");
       }
     }
-  
+
     return *(max_element(kernels.begin(), kernels.end()));
   }
-  
-  
+
+
   json getLatestKernels(json kernels) {
-    // the kernels group is now the conf with 
+    // the kernels group is now the conf with
     for(auto &kernelType: {"ck", "spk", "tspk", "fk", "ik", "iak", "pck", "lsk"}) {
         vector<json::json_pointer> catPointers = findKeyInJson(kernels, kernelType, true);
         for(auto &p : catPointers) {
-          for(auto qual: Kernel::QUALITIES) { 
+          for(auto qual: Kernel::QUALITIES) {
             if(!kernels[p].contains(qual)){
-              continue; 
+              continue;
             }
             std::vector<string> l = jsonArrayToVector(kernels[p][qual]["kernels"]);
             fs::path latest;
 
             if (!l.empty()) {
               latest = getLatestKernel(l);
-              kernels[p][qual]["kernels"] = latest; 
+              kernels[p][qual]["kernels"] = latest;
             }
           }
-          
-          if(kernels[p].contains("kernels")) { 
+
+          if(kernels[p].contains("kernels")) {
             fs::path latest = getLatestKernel(jsonArrayToVector(kernels[p]["kernels"]));
-            kernels[p]["kernels"] = latest;  
+            kernels[p]["kernels"] = latest;
           }
         }
     }
@@ -64,9 +67,9 @@ namespace SugarSpice {
         p /= "kernels";
       }
       fs::path latest = getLatestKernel(jsonArrayToVector(kernels[p]));
-      kernels[p] = latest; 
+      kernels[p] = latest;
     }
- 
+
     return kernels;
   }
 
@@ -81,28 +84,28 @@ namespace SugarSpice {
     * @param r json list of regexes
     * @returns vector of paths
    **/
-  vector<fs::path> getPathsFromRegex (fs::path root, json r) {
+  vector<string> getPathsFromRegex (string root, json r) {
       vector<string> regexes = jsonArrayToVector(r);
       regex reg(fmt::format("({})", fmt::join(regexes, "|")));
-      vector<fs::path> paths = glob(root, reg, true);
-      
+      vector<string> paths = glob(root, reg, true);
+
       return paths;
   };
-  
-  
-  json globKernels(fs::path root, json conf, string kernelType) {
+
+
+  json globKernels(string root, json conf, string kernelType) {
     vector<json::json_pointer> pointers = findKeyInJson(conf, kernelType, true);
-  
-    json ret; 
-  
+
+    json ret;
+
     // iterate pointers
-    for(auto pointer : pointers) {      
+    for(auto pointer : pointers) {
       json category = conf[pointer];
 
       if (category.contains("kernels")) {
         ret[pointer]["kernels"] = getPathsFromRegex(root, category.at("kernels"));
       }
-  
+
       if (category.contains("deps")) {
         if (category.at("deps").contains("sclk")) {
           ret[pointer]["deps"]["sclk"] = getPathsFromRegex(root, category.at("deps").at("sclk"));
@@ -114,15 +117,15 @@ namespace SugarSpice {
           ret[pointer]["deps"]["objs"] = category.at("deps").at("objs");
         }
       }
-  
-      // iterate over potential qualities 
+
+      // iterate over potential qualities
       for(auto qual: Kernel::QUALITIES) {
         if(!category.contains(qual)) {
           continue;
         }
-        
+
         ret[pointer][qual]["kernels"] = getPathsFromRegex(root, category[qual].at("kernels"));
-        
+
         if (category[qual].contains("deps")) {
           if (category[qual].at("deps").contains("sclk")) {
             ret[pointer][qual]["deps"]["sclk"] = getPathsFromRegex(root, category[qual].at("deps").at("sclk"));
@@ -136,43 +139,43 @@ namespace SugarSpice {
         }
       }
     }
-  
+
     return  ret.empty() ? "{}"_json : ret;
   }
-  
-  
-  json searchMissionKernels(fs::path root, json conf) {
+
+
+  json searchMissionKernels(string root, json conf) {
     json kernels;
-  
-    // the kernels group is now the conf with 
+
+    // the kernels group is now the conf with
     for(auto &kernelType: {"ck", "spk", "tspk", "fk", "ik", "iak", "pck", "lsk", "sclk"}) {
         kernels.merge_patch(globKernels(root, conf, kernelType));
     }
-  
+
     return kernels;
   }
-  
-  
+
+
   json searchMissionKernels(json kernels, std::vector<double> times, bool isContiguous)  {
     auto loadTimeKernels = [&](json j) -> vector<shared_ptr<Kernel>> {
       vector<json::json_pointer> p = findKeyInJson(j, "sclk", true);
       vector<string> sclks;
 
-      if (!p.empty()) { 
+      if (!p.empty()) {
         sclks = jsonArrayToVector(j[p.at(0)]);
         sort(sclks.begin(), sclks.end(), greater<string>());
       }
-  
+
       json baseConf = getMissionConfig("base");
-      fs::path dataDir = getDataDirectory();
+      string dataDir = getDataDirectory();
       baseConf = searchMissionKernels(dataDir, baseConf);
       p = findKeyInJson(baseConf, "lsk", true);
-      
+
       vector<string> lsks = jsonArrayToVector(baseConf.at(p.at(0))["kernels"]);
       sort(lsks.begin(), lsks.end(), greater<string>());
-      
+
       vector<shared_ptr<Kernel>> timeKernels(2);
-      
+
       if(lsks.size()) {
         timeKernels.emplace_back(new Kernel(lsks.at(0)));
       }
@@ -181,39 +184,39 @@ namespace SugarSpice {
       }
       return timeKernels;
     };
-  
+
     json reducedKernels;
-  
+
     vector<json::json_pointer> ckpointers = findKeyInJson(kernels, "ck", true);
     vector<json::json_pointer> spkpointers = findKeyInJson(kernels, "spk", true);
     vector<json::json_pointer> pointers(ckpointers.size() + spkpointers.size());
     merge(ckpointers.begin(), ckpointers.end(), spkpointers.begin(), spkpointers.end(), pointers.begin());
-  
+
     json newKernels = json::array();
-  
+
     // refine cks for every instrument/category
     for (auto &p : pointers) {
       json cks = kernels[p];
       if(cks.is_null() ) {
         continue;
       }
-  
+
       // load time kernels
       vector<shared_ptr<Kernel>> timeKernels = loadTimeKernels(cks);
-      
+
       for(auto qual: Kernel::QUALITIES) {
         if(!cks.contains(qual)) {
           continue;
         }
-  
+
         json ckQual = cks[qual]["kernels"];
         newKernels = json::array();
-        
+
         for(auto &kernel : ckQual) {
           vector<pair<double, double>> intervals = getTimeIntervals(kernel);
           for(auto &interval : intervals) {
             auto isInRange = [&interval](double d) -> bool {return d >= interval.first && d <= interval.second;};
-  
+
             if (isContiguous && all_of(times.cbegin(), times.cend(), isInRange)) {
               newKernels.push_back(kernel);
             }
@@ -222,7 +225,7 @@ namespace SugarSpice {
             }
           } // end of searching intervals
         } // end  of searching kernels
-        
+
         reducedKernels[p/qual/"kernels"] = newKernels;
         reducedKernels[p]["deps"] = kernels[p]["deps"];
       }

--- a/SugarSpice/src/spice_types.cpp
+++ b/SugarSpice/src/spice_types.cpp
@@ -9,11 +9,13 @@
 
 #include <nlohmann/json.hpp>
 
+#include <ghc/fs_std.hpp>
+
 #include "spice_types.h"
 #include "query.h"
 #include "utils.h"
 
-using namespace std; 
+using namespace std;
 using json = nlohmann::json;
 
 namespace SugarSpice {
@@ -36,19 +38,19 @@ namespace SugarSpice {
   }
 
 
-  const std::vector<std::string> Kernel::TYPES =  { "na", "ck", "spk", "tspk", 
-                                                    "lsk", "mk", "sclk", 
-                                                    "iak", "ik", "fk", 
+  const std::vector<std::string> Kernel::TYPES =  { "na", "ck", "spk", "tspk",
+                                                    "lsk", "mk", "sclk",
+                                                    "iak", "ik", "fk",
                                                     "dsk", "pck", "ek"};
 
   const std::vector<std::string> Kernel::QUALITIES = { "na",
                                                        "predicted",
-                                                       "nadir", 
-                                                       "reconstructed", 
+                                                       "nadir",
+                                                       "reconstructed",
                                                        "smithed"};
 
 
-  string Kernel::translateType(Kernel::Type type) { 
+  string Kernel::translateType(Kernel::Type type) {
     return Kernel::TYPES[static_cast<int>(type)];
   }
 
@@ -56,7 +58,7 @@ namespace SugarSpice {
   Kernel::Type Kernel::translateType(string type) {
     auto res = findInVector<string>(Kernel::TYPES, type);
     if (res.first) {
-      return static_cast<Kernel::Type>(res.second); 
+      return static_cast<Kernel::Type>(res.second);
     }
 
     throw invalid_argument(fmt::format("{} is not a valid kernel type", type));
@@ -70,16 +72,16 @@ namespace SugarSpice {
   Kernel::Quality Kernel::translateQuality(string qa) {
     auto res = findInVector<string>(Kernel::QUALITIES, qa);
     if (res.first) {
-      return static_cast<Kernel::Quality>(res.second); 
+      return static_cast<Kernel::Quality>(res.second);
     }
 
-    throw invalid_argument(fmt::format("{} is not a valid kernel type", qa)); 
+    throw invalid_argument(fmt::format("{} is not a valid kernel type", qa));
   }
 
 
   int Kernel::translateFrame(string frame) {
-    SpiceInt code; 
-    SpiceBoolean found; 
+    SpiceInt code;
+    SpiceBoolean found;
 
     bodn2c_c(frame.c_str(), &code, &found);
 
@@ -91,8 +93,8 @@ namespace SugarSpice {
   }
 
 
-  string Kernel::translateFrame(int frame) { 
-    SpiceChar name[128]; 
+  string Kernel::translateFrame(int frame) {
+    SpiceChar name[128];
     SpiceBoolean found;
 
     bodc2n_c(frame, 128, name, &found);
@@ -101,13 +103,13 @@ namespace SugarSpice {
       throw "Frame Code not found";
     }
 
-    return string(name); 
+    return string(name);
   }
 
 
-  Kernel::Kernel(fs::path path) { 
-    this->path = path; 
-    furnsh_c(path.string().c_str());
+  Kernel::Kernel(string path) {
+    this->path = path;
+    furnsh_c(path.c_str());
   }
 
 
@@ -119,12 +121,12 @@ namespace SugarSpice {
   double utcToEt(string utc) {
       // get lsk kernel
       json conf = getMissionConfig("base");
-      conf = globKernels(getDataDirectory(), conf, "lsk"); 
+      conf = globKernels(getDataDirectory(), conf, "lsk");
       Kernel lsk(getLatestKernel(conf.at("base").at("lsk").at("kernels")));
-  
-      SpiceDouble et; 
+
+      SpiceDouble et;
       utc2et_c(utc.c_str(), &et);
-      return et; 
+      return et;
   }
 
 

--- a/SugarSpice/tests/Fixtures.cpp
+++ b/SugarSpice/tests/Fixtures.cpp
@@ -12,7 +12,7 @@
 #include "io.h"
 
 using namespace std;
-using namespace SugarSpice; 
+using namespace SugarSpice;
 
 void TempTestingFiles::SetUp() {
   int max_tries = 10;
@@ -58,16 +58,16 @@ void KernelDataDirectories::SetUp() {
 
 
 void KernelDataDirectories::TearDown() {
-  
+
 }
 
-void KernelSet::SetUp() { 
+void KernelSet::SetUp() {
   TempTestingFiles::SetUp();
   root = tempDir;
 
   // Move Clock kernels
   // TODO: Programmatic clock kernels
-  fs::path lskPath = fs::path("data") / "naif0012.tls"; 
+  fs::path lskPath = fs::path("data") / "naif0012.tls";
   fs::path sclkPath = fs::path("data") / "lro_clkcor_2020184_v00.tsc";
   create_directory(tempDir / "clocks");
 
@@ -76,8 +76,8 @@ void KernelSet::SetUp() {
 
   // Write CK1 ------------------------------------------
   fs::create_directory(tempDir / "ck");
-  
-  int bodyCode = -85000; 
+
+  int bodyCode = -85000;
   std::string referenceFrame = "j2000";
 
   fs::path ckPath1 = tempDir / "ck" / "soc31.0001.bc";
@@ -85,7 +85,7 @@ void KernelSet::SetUp() {
   std::vector<std::vector<double>> quats = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
   std::vector<double> times1 = {110000000, 120000000};
   std::vector<double> times2 = {130000000, 140000000};
- 
+
   writeCk(ckPath1, quats, times1, bodyCode, referenceFrame, "CK ID 1",  sclkPath, lskPath, avs, "CK1");
 
   // Write CK2 ------------------------------------------
@@ -93,25 +93,25 @@ void KernelSet::SetUp() {
   avs = {{3,4,5}, {6,5,5}};
   quats = {{0.3754439, 0.3754439, 0.3754439, -0.7596879}, {-0.5632779, -0.5632779, -0.5632779, 0.21944}};
   writeCk(ckPath2, quats, times2, bodyCode, referenceFrame, "CK ID 2", sclkPath, lskPath, avs, "CK2");
-  
+
   // Write SPK1 ------------------------------------------
   fs::create_directory(tempDir / "spk");
   fs::path spkPath1 = tempDir / "spk" / "LRO_TEST_GRGM660MAT270.bsp";
 
   std::vector<std::vector<double>> velocities = {{1,1,1}, {2,2,2}};
   std::vector<std::vector<double>> positions = {{1, 1, 1}, {2, 2, 2}};
-  writeSpk(spkPath1, positions, times1, bodyCode, 1, referenceFrame, "SPK ID 1", 1, velocities, "SPK 1");  
+  writeSpk(spkPath1, positions, times1, bodyCode, 1, referenceFrame, "SPK ID 1", 1, velocities, "SPK 1");
 
   // Write SPK2 ------------------------------------------
   velocities = {{3, 3, 3}, {5, 5, 5}};
   positions = {{3, 3, 3}, {4, 4, 4}};
   fs::path spkPath2 = tempDir / "spk" / "LRO_TEST_GRGM660MAT370.bsp";
-  writeSpk(spkPath2, positions, times2, bodyCode, 1, referenceFrame, "SPK ID 2", 1, velocities, "SPK 2");  
+  writeSpk(spkPath2, positions, times2, bodyCode, 1, referenceFrame, "SPK ID 2", 1, velocities, "SPK 2");
 
   // Write IK1 -------------------------------------------
   fs::create_directory(tempDir / "ik");
 
-  fs::path ikPath1 = tempDir / "ik" / "lro_instruments_v10.ti"; 
+  fs::path ikPath1 = tempDir / "ik" / "lro_instruments_v10.ti";
   nlohmann::json jKeywords = {
     {"INS-85600_PIXEL_SAMPLES", { 5064 }},
     {"INS-85600_PIXEL_LINES", { 1 }},
@@ -120,9 +120,9 @@ void KernelSet::SetUp() {
   };
 
   writeTextKernel(ikPath1, "ik", jKeywords);
-  
+
   // Write IK2 -------------------------------------------
-  fs::path ikPath2 = tempDir / "ik" / "lro_instruments_v11.ti"; 
+  fs::path ikPath2 = tempDir / "ik" / "lro_instruments_v11.ti";
   jKeywords = {
     {"INS-85600_PIXEL_SAMPLES", { 5063 }},
     {"INS-85600_PIXEL_LINES", { 1 }},
@@ -146,11 +146,11 @@ void KernelSet::SetUp() {
     {"CK_-85620_SPK", -85}
   };
 
-  fs::path fkPath = tempDir / "fk" / "lro_frames_1111111_v01.tf"; 
+  fs::path fkPath = tempDir / "fk" / "lro_frames_1111111_v01.tf";
 
   writeTextKernel(fkPath, "fk", jKeywords);
 }
 
-void KernelSet::TearDown() { 
+void KernelSet::TearDown() {
 
 }

--- a/SugarSpice/tests/Fixtures.h
+++ b/SugarSpice/tests/Fixtures.h
@@ -5,33 +5,33 @@
 #include "gtest/gtest.h"
 #include <ghc/fs_std.hpp>
 
-using namespace std; 
+using namespace std;
 
 class TempTestingFiles : public ::testing::Test {
   protected:
     fs::path tempDir;
 
     void SetUp() override;
-    void TearDown() override; 
+    void TearDown() override;
 };
 
 
 class KernelDataDirectories : public ::testing::Test {
   protected:
 
-    vector<fs::path> paths; 
-    
+    vector<string> paths;
+
     void SetUp() override;
     void TearDown() override;
 };
 
 
-class KernelSet : public TempTestingFiles { 
-  protected: 
+class KernelSet : public TempTestingFiles {
+  protected:
 
-    fs::path root;
-    
-    void SetUp() override; 
-    void TearDown() override; 
+    string root;
+
+    void SetUp() override;
+    void TearDown() override;
 };
 

--- a/SugarSpice/tests/Paths.h
+++ b/SugarSpice/tests/Paths.h
@@ -3,14 +3,14 @@
 
 
 // paths for testing base / shared kernel queries
-std::vector<fs::path> base_paths = {
+std::vector<std::string> base_paths = {
     "/isis_data/base/kernels/sclk/naif0001.tls",
     "/isis_data/base/kernels/sclk/naif0002.tls",
     "/kernels/pck/pck00006.tpc"
 };
 
 // paths for testing messenger kernel queries
-std::vector<fs::path> mess_paths = {
+std::vector<std::string> mess_paths = {
     "/isis_data/messenger/kernels/ck/msgr_1234_v01.bc",
     "/isis_data/messenger/kernels/ck/msgr_1235_v01.bc",
     "/isis_data/messenger/kernels/ck/msgr_1235_v02.bc",
@@ -49,7 +49,7 @@ std::vector<fs::path> mess_paths = {
 };
 
 // paths for testing clementine kernel queries
-std::vector<fs::path> clem1_paths = {
+std::vector<std::string> clem1_paths = {
     "/isis_data/clementine1/kernels/ck/clem_123.bck",
     "/isis_data/clementine1/kernels/ck/clem_124.bck",
     "/isis_data/clementine1/kernels/ck/clem_125.bck",
@@ -74,7 +74,7 @@ std::vector<fs::path> clem1_paths = {
 };
 
 
-std::vector<fs::path> galileo_paths = {
+std::vector<std::string> galileo_paths = {
     "/isis_data/galileo/kernels/ck/ck90342a_plt.bc",
     "/isis_data/galileo/kernels/ck/ck90342b_plt.bc",
     "/isis_data/galileo/kernels/ck/ck90343a_plt.bc",

--- a/SugarSpice/tests/QueryTests.cpp
+++ b/SugarSpice/tests/QueryTests.cpp
@@ -11,7 +11,7 @@ using namespace std;
 using namespace SugarSpice;
 
 
-TEST(QueryTests, UnitTestGetLatestKernel) { 
+TEST(QueryTests, UnitTestGetLatestKernel) {
   vector<string> kernels = {
     "iak.0001.ti",
     "iak.0003.ti",
@@ -23,19 +23,19 @@ TEST(QueryTests, UnitTestGetLatestKernel) {
 }
 
 
-TEST(QueryTests, UnitTestGetLatestKernelError) { 
+TEST(QueryTests, UnitTestGetLatestKernelError) {
   vector<string> kernels = {
     "iak.0001.ti",
     "iak.0003.ti",
     "different/place/iak.0002.ti",
     "test/iak.4.ti",
     // different extension means different filetype and therefore error
-    "test/error.tf" 
+    "test/error.tf"
   };
 
-  try { 
+  try {
     getLatestKernel(kernels);
-    FAIL() << "expected invalid argument error"; 
+    FAIL() << "expected invalid argument error";
   }
   catch(invalid_argument &e) {
     SUCCEED();
@@ -44,7 +44,7 @@ TEST(QueryTests, UnitTestGetLatestKernelError) {
 
 
 TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsAllMess) {
-  fs::path dbPath = getMissionConfigFile("mess");
+  string dbPath = getMissionConfigFile("mess");
 
   ifstream i(dbPath);
   nlohmann::json conf;
@@ -54,7 +54,7 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsAllMess) {
   mocks.OnCallFunc(ls).Return(paths);
 
   nlohmann::json res = searchMissionKernels("/isis_data/", conf);
-  
+
   ASSERT_EQ(res["mdis"]["ck"]["reconstructed"]["kernels"].size(), 4);
   ASSERT_EQ(res["mdis"]["ck"]["smithed"]["kernels"].size(), 4);
   ASSERT_EQ(res["mdis"]["ck"]["deps"]["objs"].size(), 4);
@@ -98,7 +98,7 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsClem1) {
 
   ASSERT_EQ(res["uvvis"]["iak"]["kernels"].size(), 2);
 }
- 
+
 
 TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsGalileo) {
   fs::path dbPath = getMissionConfigFile("galileo");


### PR DESCRIPTION
Fixes #83 

There's a small amount of functionality lost because we can freely convert from string to path, but we can't convert vector<string> to vector<path>. I don't think this will matter much for the API but I'm not sure.