### PR TITLE
made clock kernels more consistent

### DIFF
--- a/SugarSpice/db/clem1.json
+++ b/SugarSpice/db/clem1.json
@@ -1,5 +1,8 @@
 {
-  "clem" : {
+  "clem1" : {
+    "sclk" : {
+      "kernels" : ["dspse[0-9]{3}.tsc"]
+    },
     "ck" : {
       "reconstructed" : {
         "kernels" : "clem_[0-9]{3}.bck"
@@ -8,8 +11,7 @@
         "kernels" : "clem_ulcn2005_6hr.bc"
       },
       "deps" : {
-        "sclk" : "dspse[0-9]{3}.tsc",
-        "objs" : ["/base/lsk"]
+        "objs" : ["/base/lsk", "/clem1/sclk"]
       }
     },
     "spk" : {
@@ -18,7 +20,7 @@
         "deps": {}
       },
       "deps" : {
-        "objs" : ["/base/lsk"]
+        "objs" : ["/base/lsk", "/clem1/sclk"]
       }
     },
     "fk" : {
@@ -34,8 +36,7 @@
     },
     "ck" : {
       "deps" : {
-        "sclk" : "dspse[0-9]{3}.tsc",
-        "objs" : ["/clem/ck/lsk"]
+        "objs" : ["/clem1/sclk", "/base/lsk"]
       }
     },
     "spk" : {
@@ -48,8 +49,7 @@
     "iak" : "nirAddendum[0-9]{3}.ti",
     "ck" : {
       "deps" : {
-        "sclk" : "dspse[0-9]{3}.tsc",
-        "objs" : ["/clem/ck/lsk"]
+        "objs" : ["/base/lsk", "/clem1/sclk"]
       }
     },
     "spk" : {

--- a/SugarSpice/db/galileo.json
+++ b/SugarSpice/db/galileo.json
@@ -1,5 +1,8 @@
 {
   "galileo" : {
+    "sclk" : {
+      "kernels" : "mk00062b.tsc"
+    },
     "ck" : {
       "reconstructed" : {
         "kernels" : ["ck[0-9]{5}.*\\.bc", "CKmerge_type3.plt.bck"],
@@ -12,9 +15,7 @@
         }
       },
       "deps" : {
-          "sclk" : "mk00062b.tsc",
-          "lsk" : "naif[0-9]{4}.tls",
-          "objs" : []
+          "objs" : ["/base/lsk", "/galileo/sclk"]
       }
     },
     "spk" : {
@@ -23,8 +24,7 @@
           "deps" : {}
         },
         "deps" : {
-            "lsk" : "naif[0-9]{4}.tls",
-            "objs" : []
+            "objs" : ["/base/lsk", "/galileo/sclk"]
         }
     },
     "iak" : {

--- a/SugarSpice/db/mess.json
+++ b/SugarSpice/db/mess.json
@@ -49,7 +49,6 @@
               "deps" : {}
             },
             "deps" : {
-                "sclk" : "messenger_[0-9]{4}.tsc",
                 "objs" : ["/base/lsk", "/mess/sclk"]
             }
         }

--- a/SugarSpice/src/utils.cpp
+++ b/SugarSpice/src/utils.cpp
@@ -461,7 +461,7 @@ namespace SugarSpice {
       }  
       
       throw runtime_error(fmt::format("Please set env var SPICEROOT, ISISDATA or ALESPICEROOT in order to proceed."));
-  }
+}
 
 
   fs::path getMissionConfigFile(string mission) {

--- a/SugarSpice/tests/FunctionalTestsSpiceQueries.cpp
+++ b/SugarSpice/tests/FunctionalTestsSpiceQueries.cpp
@@ -29,6 +29,4 @@ TEST_F(KernelSet, FunctionalTestSearchMissionKernels) {
   ASSERT_EQ( fs::path(kernels["moc"]["ik"]["kernels"].get<string>()).filename(), "lro_instruments_v11.ti");
   ASSERT_EQ( fs::path(kernels["moc"]["fk"]["kernels"].get<string>()).filename(), "lro_frames_1111111_v01.tf"); 
   ASSERT_EQ( fs::path(kernels["moc"]["sclk"]["kernels"].get<string>()).filename(), "lro_clkcor_2020184_v00.tsc"); 
-
-
 }

--- a/SugarSpice/tests/QueryTests.cpp
+++ b/SugarSpice/tests/QueryTests.cpp
@@ -86,13 +86,13 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsClem1) {
 
   nlohmann::json res = searchMissionKernels("/isis_data/", conf);
 
-  ASSERT_EQ(res["clem"]["ck"]["reconstructed"]["kernels"].size(), 4);
-  ASSERT_EQ(res["clem"]["ck"]["smithed"]["kernels"].size(), 1);
-  ASSERT_EQ(res["clem"]["ck"]["deps"]["sclk"].size(), 2);
-  ASSERT_EQ(res["clem"]["ck"]["deps"]["objs"].size(), 1);
-  ASSERT_EQ(res["clem"]["spk"]["reconstructed"]["kernels"].size(), 2);
-  ASSERT_EQ(res["clem"]["fk"]["kernels"].size(), 1);
-
+  ASSERT_EQ(res["clem1"]["ck"]["reconstructed"]["kernels"].size(), 4);
+  ASSERT_EQ(res["clem1"]["ck"]["smithed"]["kernels"].size(), 1);
+  ASSERT_EQ(res["clem1"]["ck"]["deps"]["objs"].size(), 2);
+  ASSERT_EQ(res["clem1"]["spk"]["reconstructed"]["kernels"].size(), 2);
+  ASSERT_EQ(res["clem1"]["fk"]["kernels"].size(), 1);
+  ASSERT_EQ(res["clem1"]["sclk"]["kernels"].size(), 2);
+  
   ASSERT_EQ(res["uvvis"]["ik"]["kernels"].size(), 1);
   ASSERT_EQ(res["uvvis"]["iak"]["kernels"].size(), 2);
 
@@ -116,13 +116,13 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsGalileo) {
   ASSERT_EQ(res["galileo"]["ck"]["reconstructed"]["deps"].size(), 0);
   ASSERT_EQ(res["galileo"]["ck"]["smithed"]["kernels"].size(), 3);
   ASSERT_EQ(res["galileo"]["ck"]["smithed"]["deps"]["objs"].size(), 1);
-  ASSERT_EQ(res["galileo"]["ck"]["deps"]["sclk"].size(), 1);
-  ASSERT_EQ(res["galileo"]["ck"]["deps"]["objs"].size(), 0);
+  ASSERT_EQ(res["galileo"]["ck"]["deps"]["objs"].size(), 2);
   ASSERT_EQ(res["galileo"]["spk"]["reconstructed"]["kernels"].size(), 2);
   ASSERT_EQ(res["galileo"]["iak"]["kernels"].size(), 1);
   ASSERT_EQ(res["galileo"]["pck"]["smithed"]["kernels"].size(), 2);
   ASSERT_EQ(res["galileo"]["pck"]["smithed"]["deps"].size(), 0);
   ASSERT_EQ(res["galileo"]["pck"]["na"]["kernels"].size(), 1);
   ASSERT_EQ(res["galileo"]["pck"]["na"]["deps"].size(), 0);
+  ASSERT_EQ(res["galileo"]["sclk"]["kernels"].size(), 1);
 }
 


### PR DESCRIPTION
This makes most of them match, having so many sclk/lsk deps seems to make it easy to make errors, so part of #76 we might want to just autoload lsks and sclks. 