### PR TITLE
First pass at LROC config

### DIFF
--- a/SugarSpice/db/lro.json
+++ b/SugarSpice/db/lro.json
@@ -1,25 +1,25 @@
 {
-  "moc" : { 
+  "moc" : {
       "ck" : {
           "reconstructed" : {
-              "kernels": ["soc31.*.bc", "lrolc.*.bc"]
+              "kernels": "moc42r?_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc"
           },
           "deps" : {
-            "sclk" : ["lro_clkcor_[0-9]{7}_v[0-9]{2}.tsc"],
             "objs" : ["/base/lsk", "/moc/sclk"]
           }
       },
       "spk" : {
         "reconstructed" : {
-          "kernels" : ["fdf29_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp", "fdf29r_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp"]
-        }, 
+          "kernels" : ["fdf29_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp", "fdf29r_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp"],
+          "deps" : {}
+        },
         "smithed" : {
-          "kernels" : ["LRO_.*_GRGM660.*.bsp", "LRO_.*_GRGM900C.*.BSP"]
+          "kernels" : ["LRO_.*_GRGM660.*.bsp", "LRO_.*_GRGM900C.*.BSP"],
+          "deps" : {}
         },
         "deps" : {
-          "sclk" : ["lro_clkcor_[0-9]{7}_v[0-9]{2}.tsc"],
           "objs" : ["/base/lsk", "/moc/sclk"]
-        } 
+        }
       },
       "sclk" : {
         "kernels" : ["lro_clkcor_[0-9]{7}_v[0-9]{2}.tsc"]
@@ -31,8 +31,49 @@
         "kernels" : ["lro_instruments_v[0-9]{2}.ti"]
       }
   },
-  
-  "lroc" : {
 
+  "lroc" : {
+    "ck" : {
+      "reconstructed" : {
+        "kernels" : ["lrolc_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc", "soc31_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc"],
+        "deps" : {}
+      },
+      "deps" : {
+        "objs" : ["/base/lsk", "/moc/sclk", "/moc/ck"]
+      }
+    },
+    "spk" : {
+      "reconstructed" : {
+        "kernels" : "fdf29r?_[0-9]{7}_[0-9]{7}_[nbv][0-9]{2}.bsp",
+        "deps" : {}
+      },
+      "smithed" : {
+        "kernels" : [
+          "LRO_CO_[0-9]{6}_GRGM660PRIMAT270.bsp",
+          "LRO_[A-Z]{2}_[0-9]{2}_[0-9]{6}_GRGM660PRIMAT270.bsp",
+          "LRO_CO_[0-9]{6}_GRGM900C_L600.BSP",
+          "LRO_[A-Z]{2}_[0-9]{2}_[0-9]{6}_GRGM900C_L600.BSP"],
+        "deps" : {}
+      },
+      "deps" : {
+          "objs" : ["/base/lsk", "/moc/sclk"]
+      }
+    },
+    "tspk" : {
+      "kernels" : ["de421.bsp", "moon_pa_de421_1900-2050.bpc"]
+    },
+    "fk" : {
+      "kernels" : "lro_frames_[0-9]{7}_v[0-9]{2}.tf"
+    },
+    "ik" : {
+      "kernels" :"lro_lroc_v[0-9]{2}.ti"
+    },
+    "iak" : {
+      "kernels" : "lro_instrumentAddendum_v[0-9]{2}.ti"
+    },
+    "pck" : {
+      "kernels" : ["moon_080317.tf", "moon_assoc_me.tf"],
+      "deps" : "/base/pck"
+    }
   }
 }

--- a/SugarSpice/db/test.json
+++ b/SugarSpice/db/test.json
@@ -1,0 +1,35 @@
+
+{
+    "moc" : {
+        "ck" : {
+            "reconstructed" : {
+                "kernels": ["soc31.*.bc", "lrolc.*.bc"]
+            },
+            "deps" : {
+            "sclk" : ["lro_clkcor_[0-9]{7}_v[0-9]{2}.tsc"],
+            "objs" : ["/base/lsk", "/moc/sclk"]
+            }
+        },
+        "spk" : {
+        "reconstructed" : {
+            "kernels" : ["fdf29_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp", "fdf29r_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp"]
+        },
+        "smithed" : {
+            "kernels" : ["LRO_.*_GRGM660.*.bsp", "LRO_.*_GRGM900C.*.BSP"]
+        },
+        "deps" : {
+            "sclk" : ["lro_clkcor_[0-9]{7}_v[0-9]{2}.tsc"],
+            "objs" : ["/base/lsk", "/moc/sclk"]
+        }
+        },
+        "sclk" : {
+        "kernels" : ["lro_clkcor_[0-9]{7}_v[0-9]{2}.tsc"]
+        },
+        "fk" : {
+        "kernels" : ["lro_frames_[0-9]{7}_v[0-9]{2}.tf"]
+        },
+        "ik" : {
+        "kernels" : ["lro_instruments_v[0-9]{2}.ti"]
+        }
+    }
+}

--- a/SugarSpice/tests/Fixtures.cpp
+++ b/SugarSpice/tests/Fixtures.cpp
@@ -12,7 +12,7 @@
 #include "io.h"
 
 using namespace std;
-using namespace SugarSpice; 
+using namespace SugarSpice;
 
 void TempTestingFiles::SetUp() {
   int max_tries = 10;
@@ -54,20 +54,21 @@ void KernelDataDirectories::SetUp() {
   paths.insert(paths.end(), mess_paths.begin(), mess_paths.end());
   paths.insert(paths.end(), clem1_paths.begin(), clem1_paths.end());
   paths.insert(paths.end(), galileo_paths.begin(), galileo_paths.end());
+  paths.insert(paths.end(), lro_paths.begin(), lro_paths.end());
 }
 
 
 void KernelDataDirectories::TearDown() {
-  
+
 }
 
-void KernelSet::SetUp() { 
+void KernelSet::SetUp() {
   TempTestingFiles::SetUp();
   root = tempDir;
 
   // Move Clock kernels
   // TODO: Programmatic clock kernels
-  fs::path lskPath = fs::path("data") / "naif0012.tls"; 
+  fs::path lskPath = fs::path("data") / "naif0012.tls";
   fs::path sclkPath = fs::path("data") / "lro_clkcor_2020184_v00.tsc";
   create_directory(tempDir / "clocks");
 
@@ -76,8 +77,8 @@ void KernelSet::SetUp() {
 
   // Write CK1 ------------------------------------------
   fs::create_directory(tempDir / "ck");
-  
-  int bodyCode = -85000; 
+
+  int bodyCode = -85000;
   std::string referenceFrame = "j2000";
 
   fs::path ckPath1 = tempDir / "ck" / "soc31.0001.bc";
@@ -85,7 +86,7 @@ void KernelSet::SetUp() {
   std::vector<std::vector<double>> quats = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
   std::vector<double> times1 = {110000000, 120000000};
   std::vector<double> times2 = {130000000, 140000000};
- 
+
   writeCk(ckPath1, quats, times1, bodyCode, referenceFrame, "CK ID 1",  sclkPath, lskPath, avs, "CK1");
 
   // Write CK2 ------------------------------------------
@@ -93,25 +94,25 @@ void KernelSet::SetUp() {
   avs = {{3,4,5}, {6,5,5}};
   quats = {{0.3754439, 0.3754439, 0.3754439, -0.7596879}, {-0.5632779, -0.5632779, -0.5632779, 0.21944}};
   writeCk(ckPath2, quats, times2, bodyCode, referenceFrame, "CK ID 2", sclkPath, lskPath, avs, "CK2");
-  
+
   // Write SPK1 ------------------------------------------
   fs::create_directory(tempDir / "spk");
   fs::path spkPath1 = tempDir / "spk" / "LRO_TEST_GRGM660MAT270.bsp";
 
   std::vector<std::vector<double>> velocities = {{1,1,1}, {2,2,2}};
   std::vector<std::vector<double>> positions = {{1, 1, 1}, {2, 2, 2}};
-  writeSpk(spkPath1, positions, times1, bodyCode, 1, referenceFrame, "SPK ID 1", 1, velocities, "SPK 1");  
+  writeSpk(spkPath1, positions, times1, bodyCode, 1, referenceFrame, "SPK ID 1", 1, velocities, "SPK 1");
 
   // Write SPK2 ------------------------------------------
   velocities = {{3, 3, 3}, {5, 5, 5}};
   positions = {{3, 3, 3}, {4, 4, 4}};
   fs::path spkPath2 = tempDir / "spk" / "LRO_TEST_GRGM660MAT370.bsp";
-  writeSpk(spkPath2, positions, times2, bodyCode, 1, referenceFrame, "SPK ID 2", 1, velocities, "SPK 2");  
+  writeSpk(spkPath2, positions, times2, bodyCode, 1, referenceFrame, "SPK ID 2", 1, velocities, "SPK 2");
 
   // Write IK1 -------------------------------------------
   fs::create_directory(tempDir / "ik");
 
-  fs::path ikPath1 = tempDir / "ik" / "lro_instruments_v10.ti"; 
+  fs::path ikPath1 = tempDir / "ik" / "lro_instruments_v10.ti";
   nlohmann::json jKeywords = {
     {"INS-85600_PIXEL_SAMPLES", { 5064 }},
     {"INS-85600_PIXEL_LINES", { 1 }},
@@ -120,9 +121,9 @@ void KernelSet::SetUp() {
   };
 
   writeTextKernel(ikPath1, "ik", jKeywords);
-  
+
   // Write IK2 -------------------------------------------
-  fs::path ikPath2 = tempDir / "ik" / "lro_instruments_v11.ti"; 
+  fs::path ikPath2 = tempDir / "ik" / "lro_instruments_v11.ti";
   jKeywords = {
     {"INS-85600_PIXEL_SAMPLES", { 5063 }},
     {"INS-85600_PIXEL_LINES", { 1 }},
@@ -146,11 +147,11 @@ void KernelSet::SetUp() {
     {"CK_-85620_SPK", -85}
   };
 
-  fs::path fkPath = tempDir / "fk" / "lro_frames_1111111_v01.tf"; 
+  fs::path fkPath = tempDir / "fk" / "lro_frames_1111111_v01.tf";
 
   writeTextKernel(fkPath, "fk", jKeywords);
 }
 
-void KernelSet::TearDown() { 
+void KernelSet::TearDown() {
 
 }

--- a/SugarSpice/tests/FunctionalTestsSpiceQueries.cpp
+++ b/SugarSpice/tests/FunctionalTestsSpiceQueries.cpp
@@ -12,23 +12,23 @@ using namespace std;
 using namespace SugarSpice;
 
 
-TEST_F(KernelSet, FunctionalTestSearchMissionKernels) { 
+TEST_F(KernelSet, FunctionalTestSearchMissionKernels) {
   setenv("SPICEROOT", tempDir.c_str(), true);
 
-  nlohmann::json conf = getMissionConfig("lro");
+  nlohmann::json conf = getMissionConfig("test");
 
   // load all available kernels
   nlohmann::json kernels = searchMissionKernels(root, conf);
-  
+
   // do a time query
   kernels = searchMissionKernels(kernels, {110000000, 120000001}, false);
   kernels = getLatestKernels(kernels);
 
   ASSERT_EQ( fs::path(kernels["moc"]["spk"]["smithed"]["kernels"].get<string>()).filename(), "LRO_TEST_GRGM660MAT270.bsp" );
-  ASSERT_EQ( fs::path(kernels["moc"]["ck"]["reconstructed"]["kernels"].get<string>()).filename(), "soc31.0001.bc" ); 
+  ASSERT_EQ( fs::path(kernels["moc"]["ck"]["reconstructed"]["kernels"].get<string>()).filename(), "soc31.0001.bc" );
   ASSERT_EQ( fs::path(kernels["moc"]["ik"]["kernels"].get<string>()).filename(), "lro_instruments_v11.ti");
-  ASSERT_EQ( fs::path(kernels["moc"]["fk"]["kernels"].get<string>()).filename(), "lro_frames_1111111_v01.tf"); 
-  ASSERT_EQ( fs::path(kernels["moc"]["sclk"]["kernels"].get<string>()).filename(), "lro_clkcor_2020184_v00.tsc"); 
+  ASSERT_EQ( fs::path(kernels["moc"]["fk"]["kernels"].get<string>()).filename(), "lro_frames_1111111_v01.tf");
+  ASSERT_EQ( fs::path(kernels["moc"]["sclk"]["kernels"].get<string>()).filename(), "lro_clkcor_2020184_v00.tsc");
 
 
 }

--- a/SugarSpice/tests/Paths.h
+++ b/SugarSpice/tests/Paths.h
@@ -93,3 +93,60 @@ std::vector<fs::path> galileo_paths = {
 
     "/isis_data/galileo/kernels/pck/pck00010_msgr_v23_europa2020.tpc"
 };
+
+std::vector<fs::path> lro_paths = {
+    "/isis_data/lro/kernels/tspk/de421.bsp",
+    "/isis_data/lro/kernels/tspk/moon_pa_de421_1900-2050.bpc",
+
+    "/isis_data/lro/kernels/fk/lro_frames_2012255_v02.tf",
+    "/isis_data/lro/kernels/fk/lro_frames_2014049_v01.tf",
+
+    "/isis_data/lro/kernels/ik/lro_lroc_v17.ti",
+    "/isis_data/lro/kernels/ik/lro_lroc_v18.ti",
+
+    "/isis_data/lro/kernels/iak/lro_instrumentAddendum_v03.ti",
+    "/isis_data/lro/kernels/iak/lro_instrumentAddendum_v04.ti",
+
+    "/isis_data/lro/kernels/pck/moon_080317.tf",
+    "/isis_data/lro/kernels/pck/moon_assoc_me.tf",
+
+    "/isis_data/lro/kernels/ck/moc42_2021272_2021273_v01.bc",
+    "/isis_data/lro/kernels/ck/moc42_2021273_2021274_v01.bc",
+    "/isis_data/lro/kernels/ck/moc42_2021274_2021275_v01.bc",
+    "/isis_data/lro/kernels/ck/moc42_2021275_2021276_v01.bc",
+    "/isis_data/lro/kernels/ck/moc42r_2021120_2021152_v01.bc",
+    "/isis_data/lro/kernels/ck/moc42r_2021151_2021182_v01.bc",
+    "/isis_data/lro/kernels/ck/moc42r_2021181_2021213_v01.bc",
+    "/isis_data/lro/kernels/ck/moc42r_2021212_2021244_v01.bc",
+    "/isis_data/lro/kernels/ck/lrolc_2021120_2021152_v01.bc",
+    "/isis_data/lro/kernels/ck/lrolc_2021151_2021182_v01.bc",
+    "/isis_data/lro/kernels/ck/lrolc_2021181_2021213_v01.bc",
+    "/isis_data/lro/kernels/ck/lrolc_2021212_2021244_v01.bc",
+    "/isis_data/lro/kernels/ck/soc31_2021273_2021274_v01.bc",
+    "/isis_data/lro/kernels/ck/soc31_2021274_2021275_v01.bc",
+    "/isis_data/lro/kernels/ck/soc31_2021275_2021276_v01.bc",
+    "/isis_data/lro/kernels/ck/soc31_2021276_2021277_v01.bc",
+
+    "/isis_data/lro/kernels/spk/fdf29_2021273_2021274_b01.bsp",
+    "/isis_data/lro/kernels/spk/fdf29_2021274_2021275_n01.bsp",
+    "/isis_data/lro/kernels/spk/fdf29_2021275_2021276_n01.bsp",
+    "/isis_data/lro/kernels/spk/fdf29_2021276_2021277_n01.bsp",
+    "/isis_data/lro/kernels/spk/fdf29r_2021121_2021152_v01.bsp",
+    "/isis_data/lro/kernels/spk/fdf29r_2021152_2021182_v01.bsp",
+    "/isis_data/lro/kernels/spk/fdf29r_2021182_2021213_v01.bsp",
+    "/isis_data/lro/kernels/spk/fdf29r_2021213_2021244_v01.bsp",
+    "/isis_data/lro/kernels/spk/LRO_CO_201308_GRGM660PRIMAT270.bsp",
+    "/isis_data/lro/kernels/spk/LRO_CO_201311_GRGM900C_L600.BSP",
+    "/isis_data/lro/kernels/spk/LRO_ES_08_201308_GRGM660PRIMAT270.bsp",
+    "/isis_data/lro/kernels/spk/LRO_ES_09_201308_GRGM660PRIMAT270.bsp",
+    "/isis_data/lro/kernels/spk/LRO_NO_12_201308_GRGM660PRIMAT270.bsp",
+    "/isis_data/lro/kernels/spk/LRO_NO_13_201308_GRGM660PRIMAT270.bsp",
+    "/isis_data/lro/kernels/spk/LRO_SM_25_201311_GRGM900C_L600.BSP",
+    "/isis_data/lro/kernels/spk/LRO_SM_26_201311_GRGM900C_L600.BSP",
+    "/isis_data/lro/kernels/spk/LRO_ES_85_201910_GRGM900C_L600.BSP",
+    "/isis_data/lro/kernels/spk/LRO_ES_86_201910_GRGM900C_L600.BSP",
+    "/isis_data/lro/kernels/spk/LRO_NO_12_201311_GRGM900C_L600.BSP",
+    "/isis_data/lro/kernels/spk/LRO_NO_13_201311_GRGM900C_L600.BSP",
+    "/isis_data/lro/kernels/spk/LRO_SM_25_201308_GRGM660PRIMAT270.bsp",
+    "/isis_data/lro/kernels/spk/LRO_SM_26_201308_GRGM660PRIMAT270.bsp"
+};

--- a/SugarSpice/tests/QueryTests.cpp
+++ b/SugarSpice/tests/QueryTests.cpp
@@ -11,7 +11,7 @@ using namespace std;
 using namespace SugarSpice;
 
 
-TEST(QueryTests, UnitTestGetLatestKernel) { 
+TEST(QueryTests, UnitTestGetLatestKernel) {
   vector<string> kernels = {
     "iak.0001.ti",
     "iak.0003.ti",
@@ -23,19 +23,19 @@ TEST(QueryTests, UnitTestGetLatestKernel) {
 }
 
 
-TEST(QueryTests, UnitTestGetLatestKernelError) { 
+TEST(QueryTests, UnitTestGetLatestKernelError) {
   vector<string> kernels = {
     "iak.0001.ti",
     "iak.0003.ti",
     "different/place/iak.0002.ti",
     "test/iak.4.ti",
     // different extension means different filetype and therefore error
-    "test/error.tf" 
+    "test/error.tf"
   };
 
-  try { 
+  try {
     getLatestKernel(kernels);
-    FAIL() << "expected invalid argument error"; 
+    FAIL() << "expected invalid argument error";
   }
   catch(invalid_argument &e) {
     SUCCEED();
@@ -54,7 +54,7 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsAllMess) {
   mocks.OnCallFunc(ls).Return(paths);
 
   nlohmann::json res = searchMissionKernels("/isis_data/", conf);
-  
+
   ASSERT_EQ(res["mdis"]["ck"]["reconstructed"]["kernels"].size(), 4);
   ASSERT_EQ(res["mdis"]["ck"]["smithed"]["kernels"].size(), 4);
   ASSERT_EQ(res["mdis"]["ck"]["deps"]["objs"].size(), 4);
@@ -98,7 +98,7 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsClem1) {
 
   ASSERT_EQ(res["uvvis"]["iak"]["kernels"].size(), 2);
 }
- 
+
 
 TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsGalileo) {
   fs::path dbPath = getMissionConfigFile("galileo");
@@ -124,5 +124,29 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsGalileo) {
   ASSERT_EQ(res["galileo"]["pck"]["smithed"]["deps"].size(), 0);
   ASSERT_EQ(res["galileo"]["pck"]["na"]["kernels"].size(), 1);
   ASSERT_EQ(res["galileo"]["pck"]["na"]["deps"].size(), 0);
+}
+
+
+TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsLRO) {
+  fs::path dbPath = getMissionConfigFile("lro");
+
+  ifstream i(dbPath);
+  nlohmann::json conf;
+  i >> conf;
+
+  MockRepository mocks;
+  mocks.OnCallFunc(ls).Return(paths);
+
+  nlohmann::json res = searchMissionKernels("/isis_data/", conf);
+
+  EXPECT_EQ(res["lroc"]["ck"]["reconstructed"]["kernels"].size(), 8);
+  EXPECT_EQ(res["lroc"]["ck"]["deps"]["objs"].size(), 3);
+  EXPECT_EQ(res["lroc"]["spk"]["reconstructed"]["kernels"].size(), 8);
+  EXPECT_EQ(res["lroc"]["spk"]["smithed"]["kernels"].size(), 14);
+  EXPECT_EQ(res["lroc"]["iak"]["kernels"].size(), 2);
+  EXPECT_EQ(res["lroc"]["ik"]["kernels"].size(), 2);
+  EXPECT_EQ(res["lroc"]["pck"]["kernels"].size(), 2);
+  EXPECT_EQ(res["lroc"]["fk"]["kernels"].size(), 2);
+  EXPECT_EQ(res["lroc"]["tspk"]["kernels"].size(), 2);
 }
 


### PR DESCRIPTION
I noticed that the moc config section was incorrect and had several of the lroc kernels in it. So, I updated it to better match the moc kerneldb ISIS uses. I took the old moc config and put it in a new test config file because it's used by the FunctionalTestSearchMissionKernels test.

I'm putting this up as a draft as I'm not 100% sure it does everything we need for LROC but it's finding the correct kernel sets. Is there a good way to test that this actually duplicates the LROC kernel setup in ISIS?